### PR TITLE
refactor: Clean up and centralize swift reference type code into runtime

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -55,8 +55,10 @@ jobs:
         shell: zsh {0}
         run: |
           set -euxo pipefail
-          cd integration-tests/TestAPI-bindings
 
+          (cd kotlin-runtime; ./gradlew publishToMavenLocal)
+
+          cd integration-tests/TestAPI-bindings
           swift run -- fishy-joes --kotlin-fast generate build test
 
   integration-tests-linux:
@@ -114,6 +116,8 @@ jobs:
         shell: zsh {0}
         run: |
           set -euxo pipefail
-          cd integration-tests/TestAPI-bindings
 
+          (cd kotlin-runtime; ./gradlew publishToMavenLocal)
+
+          cd integration-tests/TestAPI-bindings
           swift run -- fishy-joes --kotlin-fast build test

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -2,6 +2,9 @@ name: "Integration tests"
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   integration-tests-mac:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,10 +1,13 @@
-name: Mac
+name: Build & test
 
 on:
   workflow_dispatch:
   pull_request:
   release:
     types: [published]
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center"><img src="documentation/logo.png" alt="FishyJoes" width="265" height="265"/></p>
 
 # Status
-![Mac](https://github.com/cricut/FishyJoes/actions/workflows/mac.yml/badge.svg)
-![Integration Tests](https://github.com/cricut/FishyJoes/actions/workflows/integration-tests.yaml/badge.svg)
+![Mac](https://github.com/cricut/FishyJoes/actions/workflows/mac.yml/badge.svg?branch=main)
+![Integration Tests](https://github.com/cricut/FishyJoes/actions/workflows/integration-tests.yaml/badge.svg?branch=main)
 
 # Description
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center"><img src="documentation/logo.png" alt="FishyJoes" width="265" height="265"/></p>
 
 # Status
-![Mac](https://github.com/cricut/FishyJoes/actions/workflows/mac.yml/badge.svg?branch=main)
-![Integration Tests](https://github.com/cricut/FishyJoes/actions/workflows/integration-tests.yaml/badge.svg?branch=main)
 
+[![Build & test](https://github.com/cricut/FishyJoes/actions/workflows/mac.yml/badge.svg?branch=main)](https://github.com/cricut/FishyJoes/actions/workflows/mac.yml)
+[![Integration tests](https://github.com/cricut/FishyJoes/actions/workflows/integration-tests.yaml/badge.svg?branch=main)](https://github.com/cricut/FishyJoes/actions/workflows/integration-tests.yaml)
 # Description
 
 Generates bindings for (some) swift library code that can be called from TypeScript and Kotlin.

--- a/Sources/FishyJoesCore/KotlinTranslate.swift
+++ b/Sources/FishyJoesCore/KotlinTranslate.swift
@@ -15,12 +15,13 @@ class KotlinTranslate {
         let containingNamespace: String
 
         if let selfType = method.definedIn {
-            containingNamespace = context.resolve(type: selfType).sourceType.name
+            let resolved = context.resolve(type: selfType)
+            containingNamespace = resolved.sourceType.name
 
             if method.isStatic {
                 selfExpression = containingNamespace
             } else {
-                selfExpression = "\(containingNamespace).fromJava(_javaThis, env: _javaEnv)"
+                selfExpression = "\(resolved.converterType.name).fromJava(_javaThis, env: _javaEnv)"
             }
         } else {
             containingNamespace = context.module
@@ -190,7 +191,7 @@ class KotlinTranslate {
                     javaTypeListFragment.output("try \(resolved.converterType.name).javaSetup(env: env)")
                     if case .named = type {
                         if let nativeMethods = allMethods[type.name] {
-                            javaTypeListFragment.outputBlock("try env.RegisterNatives(\(type.name).javaClass,", closeWith: ")") {
+                            javaTypeListFragment.outputBlock("try env.RegisterNatives(\(resolved.converterType.name).javaClass,", closeWith: ")") {
                                 for (method, signature, cName) in nativeMethods {
                                     let isLast = cName == nativeMethods.last?.cName
                                     javaTypeListFragment.outputBlock("JNINativeMethod(", closeWith: isLast ? ")" : "),") {

--- a/Sources/FishyJoesCore/TranslatedTypes/TranslatedReference.swift
+++ b/Sources/FishyJoesCore/TranslatedTypes/TranslatedReference.swift
@@ -122,23 +122,10 @@ struct TranslatedReference: TranslatedType {
         )
         fragment.outputBlock("extension \(sourceType.name): JavaMutator {") {
             fragment.output("public static var javaClass: jclass?")
-            fragment.output("private static var _refFieldID: jfieldID!")
             fragment.output("private static var _constructorMethodID: jmethodID!")
 
             fragment.outputBlock("public static func fromJava(_ value: jobject?, env: Env) throws -> Self {") {
-                fragment.output("let longRef = UInt(env.GetLongField(value, _refFieldID))")
-                fragment.output("return try Box<\(sourceType.name)>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value")
-            }
-
-            fragment.outputBlock("static let _javaFinalizer: @convention(c)(", newLineTerminated: false) {
-                fragment.output("UnsafeMutablePointer<JNIEnv?>,")
-                fragment.output("jobject")
-            }
-            fragment.outputBlock(" -> Void = { env, this in", closeWith: "}") {
-                fragment.outputBlock("FishyJoesJavaRuntime.callbackBody(env) { env in", closeWith: "}") {
-                    fragment.output("let longRef = UInt(env.GetLongField(this, _refFieldID))")
-                    fragment.output("Box<\(sourceType.name)>.releaseOpaque(try javaNonNull(UnsafeMutablePointer(bitPattern: longRef)))")
-                }
+                fragment.output("try Box<\(sourceType.name)>.fromJava(value, env: env).value")
             }
 
             fragment.outputBlock("public static func toJava(_ value: Self, env: Env) throws -> jobject? {") {
@@ -147,14 +134,13 @@ struct TranslatedReference: TranslatedType {
             }
 
             fragment.outputBlock("public static func javaSetup(env: Env) throws {") {
+                fragment.output("try AnyBox.javaSetup(env: env)")
                 fragment.output("javaClass = try env.globalRef(env.FindClass(\"\(className)\"))")
-                fragment.output("_refFieldID = try env.GetFieldID(javaClass, \"_swiftReference\", \"J\")")
                 fragment.output("_constructorMethodID = try env.GetMethodID(javaClass, \"<init>\", \"(J)V\")")
             }
 
             fragment.outputBlock("public static func mutateJava<R>(_ this: jobject?, env: Env, body: (inout Self) throws -> R) throws -> R {") {
-                fragment.output("let longRef = UInt(env.GetLongField(this, _refFieldID))")
-                fragment.output("return try body(&Box<\(sourceType.name)>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value)")
+                fragment.output("try body(&Box<\(sourceType.name)>.fromJava(this, env: env).value)")
             }
 
             if equatable {
@@ -187,30 +173,12 @@ struct TranslatedReference: TranslatedType {
                     }
                 }
             }
-            fragment.outputBlock("static let _javaToString: @convention(c)(", newLineTerminated: false) {
-                fragment.output("UnsafeMutablePointer<JNIEnv?>,")
-                fragment.output("jobject?")
-            }
-            fragment.outputBlock(" -> String.CType = { _javaEnv, _javaThis in", closeWith: "}") {
-                fragment.outputBlock("FishyJoesJavaRuntime.callbackBody(_javaEnv) { _javaEnv in", closeWith: "}") {
-                    fragment.outputBlock("try String.toJava(") {
-                        fragment.output("\"\\(\(sourceType.name).fromJava(_javaThis, env: _javaEnv))\",")
-                        fragment.output("env: _javaEnv")
-                    }
-                }
-            }
         }
 
-        context.kotlinTranslator.allMethods[sourceType.name, default: []].append(
-            (javaName: "__jni_finalize", signature: "()V" , cName: "\(sourceType.name)._javaFinalizer")
-        )
-        context.kotlinTranslator.allMethods[sourceType.name, default: []].append(
-            (javaName: "__jni_toString", signature: "()Ljava/lang/String;" , cName: "\(sourceType.name)._javaToString")
-        )
         if equatable {
             context.kotlinTranslator.allMethods[sourceType.name, default: []].append(
                 (
-                    javaName: "__jni__swiftEquals",
+                    javaName: "__jni_swiftEquals",
                     signature: "(\(jniType.asSignature)\(jniType.asSignature))Z",
                     cName: "\(sourceType.name)._javaEquals"
                 )
@@ -237,7 +205,7 @@ struct TranslatedReference: TranslatedType {
                         documentation: [],
                         isStatic: true,
                         isOverride: false,
-                        name: "_swiftEquals",
+                        name: "swiftEquals",
                         parameters: [
                             (labelComment: nil, name: "lhs", type: kotlinType),
                             (labelComment: nil, name: "rhs", type: kotlinType),
@@ -258,7 +226,7 @@ struct TranslatedReference: TranslatedType {
                             (labelComment: nil, name: "other", type: .optional(.named(package: nil, name: "Any"))),
                         ],
                         returnType: .named(package: nil, name: "Boolean"),
-                        body: "(other is \(kotlinType.kotlinType)) && __jni__swiftEquals(this, other)"
+                        body: "(other is \(kotlinType.kotlinType)) && __jni_swiftEquals(this, other)"
                     )
                 )
             )
@@ -278,42 +246,27 @@ struct TranslatedReference: TranslatedType {
                 )
             )
         }
-        fieldsAndMethods.append(
-            .method(
-                KotlinClass.Method(
-                    documentation: [],
-                    isStatic: false,
-                    isOverride: true,
-                    name: "toString",
-                    parameters: [],
-                    returnType: .named(package: nil, name: "String"),
-                    body: nil
-                )
-            )
-        )
 
-        context.kotlinClasses.append(
-            KotlinProductClass(
-                module: context.module,
-                documentation: documentation,
-                name: nodeName,
-                constructor: .init(
-                    private: true,
-                    fields: [
-                        .init(
-                            documentation: [],
-                            isStatic: false,
-                            isOverride: false,
-                            readOnly: true,
-                            name: "_swiftReference",
-                            type: .named(package: nil, name: "Long")
-                        ),
-                    ]
-                ),
-                fieldsAndMethods: fieldsAndMethods,
-                finalizer: true
-            )
+        let product = KotlinProductClass(
+            module: context.module,
+            documentation: documentation,
+            name: nodeName,
+            constructor: .init(
+                private: true,
+                fields: [
+                    .init(
+                        documentation: [],
+                        isStatic: false,
+                        isOverride: false,
+                        readOnly: true,
+                        name: "_swiftReference",
+                        type: .named(package: nil, name: "Long")
+                    ),
+                ]
+            ),
+            fieldsAndMethods: fieldsAndMethods
         )
+        context.kotlinClasses.append(product)
 
         return fragment
     }

--- a/Sources/FishyJoesCore/TranslatedTypes/TranslatedStruct.swift
+++ b/Sources/FishyJoesCore/TranslatedTypes/TranslatedStruct.swift
@@ -193,7 +193,6 @@ struct TranslatedStruct: TranslatedType {
                 var constructorDescriptor = ""
                 for storedVar in storedVariables {
                     let resolved = context.resolve(type: storedVar.typeName.better)
-                    let converterType = resolved.converterType
                     fragment.output("_java_\(storedVar.name)_id = try env.GetFieldID(javaClass, \"\(storedVar.name)\", \"\(resolved.jniType.asSignature)\")")
                     constructorDescriptor += resolved.jniType.asSignature
                 }

--- a/Sources/FishyJoesCore/Unparse/KotlinClass.swift
+++ b/Sources/FishyJoesCore/Unparse/KotlinClass.swift
@@ -201,15 +201,13 @@ class KotlinProductClass: KotlinClass {
     let constructor: Constructor
     let fields: [Variable]
     let methods: [Method]
-    let finalizer: Bool
 
     init(
         module: String,
         documentation: [String],
         name: String,
         constructor: Constructor,
-        fieldsAndMethods: [MethodOrVariable],
-        finalizer: Bool = false
+        fieldsAndMethods: [MethodOrVariable]
     ) {
         self.constructor = constructor
         self.fields = fieldsAndMethods.compactMap {
@@ -224,7 +222,6 @@ class KotlinProductClass: KotlinClass {
             }
             return method
         }
-        self.finalizer = finalizer
         super.init(module: module, documentation: documentation, name: name)
     }
 
@@ -244,11 +241,6 @@ class KotlinProductClass: KotlinClass {
         fragment.outputBlock(" {") {
             fields.filter { !$0.isStatic }.forEach { output(field: $0, to: fragment) }
             methods.filter { !$0.isStatic }.forEach { output(method: $0, to: fragment) }
-
-            if finalizer {
-                fragment.output("protected fun finalize() = __jni_finalize()")
-                fragment.output("private external fun __jni_finalize()")
-            }
 
             fragment.blankLine()
 

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -306,7 +306,7 @@ extension CodeGen {
                 case .kotlinSystem:
                     try cmd("mkdir", "-p", platform.outputDir).run()
                     try cmd("cp", "\(platform.buildDir)/lib\(config.module)-java.\(dylibExt)", platform.outputDir).run()
-                case .kotlinAndroid(let arch):
+                case .kotlinAndroid:
                     try cmd("mkdir", "-p", platform.outputDir).run()
                     try cmd("cp", "\(platform.buildDir)/lib\(config.module)-java.so", platform.outputDir).run()
                 }

--- a/Sources/FishyJoesJavaRuntime/Box+Java.swift
+++ b/Sources/FishyJoesJavaRuntime/Box+Java.swift
@@ -1,0 +1,55 @@
+import Foundation
+import JNI
+import FishyJoesCommonRuntime
+
+extension Box {
+    public static func fromJava(_ value: jobject?, env: Env) throws -> Box<T> {
+        try Box(inner: AnyBox.fromJava(value, env: env))
+    }
+}
+
+extension AnyBox {
+    static var javaClass: jclass?
+    static var refFieldID: jfieldID?
+
+    public static func fromJava(_ value: jobject?, env: Env) throws -> AnyBox {
+        let longRef = UInt(env.GetLongField(value, refFieldID))
+        return try takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef)))
+    }
+
+    private static let finalize: @convention(c) (UnsafeMutablePointer<JNIEnv?>, jobject) -> Void = { env, this in
+        callbackBody(env) { env in
+            let longRef = UInt(env.GetLongField(this, refFieldID))
+            releaseOpaque(try javaNonNull(UnsafeMutablePointer(bitPattern: longRef)))
+        }
+    }
+
+    private static let toString: @convention(c) (UnsafeMutablePointer<JNIEnv?>, jobject) -> jobject? = { env, this in
+        callbackBody(env) { env in
+            try String.toJava("\(fromJava(this, env: env))", env: env)
+        }
+    }
+
+    public static func javaSetup(env: Env) throws {
+        guard javaClass == nil else { return }
+
+        let bag = CStringBag()
+
+        javaClass = try env.globalRef(env.FindClass("com/cricut/fishyjoes/runtime/SwiftReference"))
+        refFieldID = try env.GetFieldID(javaClass, "swiftReference", "J")
+
+        try env.RegisterNatives(
+            javaClass,
+            JNINativeMethod(
+                name: bag.add("swiftFinalize"),
+                signature: bag.add("()V"),
+                fnPtr: unsafeBitCast(finalize, to: UnsafeMutableRawPointer.self)
+            ),
+            JNINativeMethod(
+                name: bag.add("swiftToString"),
+                signature: bag.add("()Ljava/lang/String;"),
+                fnPtr: unsafeBitCast(toString, to: UnsafeMutableRawPointer.self)
+            )
+        )
+    }
+}

--- a/Sources/FishyJoesJavaRuntime/JavaFunction.swift
+++ b/Sources/FishyJoesJavaRuntime/JavaFunction.swift
@@ -22,30 +22,12 @@ private enum SwiftFunctionImpl {
     static var implClass: jclass?
     static var constructor: jmethodID?
     static var invokeMethods: [Int: jmethodID] = [:]
-    static var refFieldID: jfieldID?
-
-    private static let finalizeFunctionObject: @convention(c) (UnsafeMutablePointer<JNIEnv?>, jobject) -> Void = { env, this in
-        callbackBody(env) { env in
-            let longRef = UInt(env.GetLongField(this, refFieldID))
-            AnyBox.releaseOpaque(try javaNonNull(UnsafeMutablePointer(bitPattern: longRef)))
-        }
-    }
 
     public static func javaSetup(arity: Int, invokePointer: UnsafeMutableRawPointer, env: Env) throws {
-        var methods: [JNINativeMethod] = []
-        let bag = CStringBag()
-
+        try AnyBox.javaSetup(env: env)
         if implClass == nil {
             implClass = try env.globalRef(env.FindClass("com/cricut/fishyjoes/runtime/SwiftFunctionImpl"))
             constructor = try env.GetMethodID(implClass, "<init>", "(IJ)V")
-            refFieldID = try env.GetFieldID(implClass, "_swiftReference", "J")
-            methods.append(
-                JNINativeMethod(
-                    name: bag.add("finalize"),
-                    signature: bag.add("()V"),
-                    fnPtr: unsafeBitCast(finalizeFunctionObject, to: UnsafeMutableRawPointer.self)
-                )
-            )
         }
 
         if invokeMethods[arity] == nil {
@@ -53,7 +35,9 @@ private enum SwiftFunctionImpl {
             let obj = "Ljava/lang/Object;"
             let invokeSignature = "(\(String(repeating: obj, count: arity)))\(obj)"
 
-            methods.append(
+            let bag = CStringBag()
+            try env.RegisterNatives(
+                implClass,
                 JNINativeMethod(
                     name: bag.add("invoke"),
                     signature: bag.add(invokeSignature),
@@ -61,10 +45,6 @@ private enum SwiftFunctionImpl {
                 )
             )
             invokeMethods[arity] = try env.GetMethodID(functionClass, "invoke", invokeSignature)
-        }
-
-        if methods.count > 0 {
-            try javaOk(env.RegisterNatives(implClass, methods: methods))
         }
     }
 }
@@ -76,9 +56,7 @@ private struct AnyFunction0 {
 
     static let cInvoke: @convention(c) (UnsafeMutablePointer<JNIEnv?>, jobject) -> jobject? = { env, this in
         callbackBody(env) { env in
-            let longRef = UInt(env.GetLongField(this, SwiftFunctionImpl.refFieldID))
-            let fun = try Box<Self>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value
-            return try fun.invoke(env)
+            try Box<Self>.fromJava(this, env: env).value.invoke(env)
         }
     }
 }
@@ -88,9 +66,7 @@ private struct AnyFunction1 {
 
     static let cInvoke: @convention(c) (UnsafeMutablePointer<JNIEnv?>, jobject, jobject?) -> jobject? = { env, this, p0 in
         callbackBody(env) { env in
-            let longRef = UInt(env.GetLongField(this, SwiftFunctionImpl.refFieldID))
-            let fun = try Box<Self>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value
-            return try fun.invoke(env, p0)
+            try Box<Self>.fromJava(this, env: env).value.invoke(env, p0)
         }
     }
 }
@@ -100,9 +76,7 @@ private struct AnyFunction2 {
 
     static let cInvoke: @convention(c) (UnsafeMutablePointer<JNIEnv?>, jobject, jobject?, jobject?) -> jobject? = { env, this, p0, p1 in
         callbackBody(env) { env in
-            let longRef = UInt(env.GetLongField(this, SwiftFunctionImpl.refFieldID))
-            let fun = try Box<Self>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value
-            return try fun.invoke(env, p0, p1)
+            try Box<Self>.fromJava(this, env: env).value.invoke(env, p0, p1)
         }
     }
 }

--- a/Sources/JavaRuntimeTestHarness/Harness.swift
+++ b/Sources/JavaRuntimeTestHarness/Harness.swift
@@ -1,7 +1,6 @@
 import FishyJoesJavaRuntime
 
 var refClass: jclass?
-var refFieldID: jfieldID?
 var refConstructorID: jmethodID?
 
 @_cdecl("JNI_OnLoad")
@@ -29,13 +28,12 @@ public func JNIOnLoad(vm: UnsafeMutablePointer<JavaVM?>, reserved: UnsafeMutable
             ),
             JNINativeMethod(
                 name: bag.add("makeReference"),
-                signature: bag.add("()Lcom/cricut/fishyjoes/runtime/SwiftReference;"),
+                signature: bag.add("()Lcom/cricut/fishyjoes/runtime/TestReference;"),
                 fnPtr: unsafeBitCast(java_ref_make, to: UnsafeMutableRawPointer.self)
             )
         )
 
-        refClass = try env.globalRef(env.FindClass("com/cricut/fishyjoes/runtime/SwiftReference"))
-        refFieldID = try env.GetFieldID(refClass, "ref", "J")
+        refClass = try env.globalRef(env.FindClass("com/cricut/fishyjoes/runtime/TestReference"))
         refConstructorID = try env.GetMethodID(refClass, "<init>", "(J)V")
         try env.RegisterNatives(
             refClass,
@@ -82,16 +80,13 @@ let java_ref_make: @convention(c) (UnsafeMutablePointer<JNIEnv?>, jobject) -> jo
 
 let java_ref_append: @convention(c) (UnsafeMutablePointer<JNIEnv?>, jobject, jlong) -> Void = { env, this, appendee in
     FishyJoesJavaRuntime.callbackBody(env) { env in
-        let longRef = UInt(env.GetLongField(this, refFieldID))
-        let box = try Box<[Int64]>.takeUnretainedOpaque(UnsafeMutablePointer(bitPattern: longRef)!)
-        box.value.append(Int64(appendee))
+        try Box<[Int64]>.fromJava(this, env: env).value.append(Int64(appendee))
     }
 }
 
 let java_ref_addr: @convention(c) (UnsafeMutablePointer<JNIEnv?>, jobject) -> jlong = { env, this in
     FishyJoesJavaRuntime.callbackBody(env) { env in
-        let longRef = UInt(env.GetLongField(this, refFieldID))
-        let box = try Box<[Int64]>.takeUnretainedOpaque(UnsafeMutablePointer(bitPattern: longRef)!)
+        let box = try Box<[Int64]>.fromJava(this, env: env)
         let storage = { (x: UnsafeRawPointer) in x }(box.value)
         return jlong(UInt(bitPattern: storage))
     }
@@ -99,8 +94,7 @@ let java_ref_addr: @convention(c) (UnsafeMutablePointer<JNIEnv?>, jobject) -> jl
 
 let java_ref_log: @convention(c) (UnsafeMutablePointer<JNIEnv?>, jobject) -> Void = { env, this in
     FishyJoesJavaRuntime.callbackBody(env) { env in
-        let longRef = UInt(env.GetLongField(this, refFieldID))
-        let box = try Box<[Int64]>.takeUnretainedOpaque(UnsafeMutablePointer(bitPattern: longRef)!)
+        let box = try Box<[Int64]>.fromJava(this, env: env)
         print(box.value)
     }
 }

--- a/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/Bytes+java.swift
+++ b/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/Bytes+java.swift
@@ -6,43 +6,20 @@ import TestAPI
 
 extension Bytes: JavaMutator {
     public static var javaClass: jclass?
-    private static var _refFieldID: jfieldID!
     private static var _constructorMethodID: jmethodID!
     public static func fromJava(_ value: jobject?, env: Env) throws -> Self {
-        let longRef = UInt(env.GetLongField(value, _refFieldID))
-        return try Box<Bytes>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value
-    }
-    static let _javaFinalizer: @convention(c)(
-        UnsafeMutablePointer<JNIEnv?>,
-        jobject
-    ) -> Void = { env, this in
-        FishyJoesJavaRuntime.callbackBody(env) { env in
-            let longRef = UInt(env.GetLongField(this, _refFieldID))
-            Box<Bytes>.releaseOpaque(try javaNonNull(UnsafeMutablePointer(bitPattern: longRef)))
-        }
+        try Box<Bytes>.fromJava(value, env: env).value
     }
     public static func toJava(_ value: Self, env: Env) throws -> jobject? {
         let ptr = jvalue(j: jlong(UInt(bitPattern: Box(value).retainedOpaque())))
         return try env.NewObject(javaClass, _constructorMethodID, ptr)
     }
     public static func javaSetup(env: Env) throws {
+        try AnyBox.javaSetup(env: env)
         javaClass = try env.globalRef(env.FindClass("com/cricut/testapi/Bytes"))
-        _refFieldID = try env.GetFieldID(javaClass, "_swiftReference", "J")
         _constructorMethodID = try env.GetMethodID(javaClass, "<init>", "(J)V")
     }
     public static func mutateJava<R>(_ this: jobject?, env: Env, body: (inout Self) throws -> R) throws -> R {
-        let longRef = UInt(env.GetLongField(this, _refFieldID))
-        return try body(&Box<Bytes>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value)
-    }
-    static let _javaToString: @convention(c)(
-        UnsafeMutablePointer<JNIEnv?>,
-        jobject?
-    ) -> String.CType = { _javaEnv, _javaThis in
-        FishyJoesJavaRuntime.callbackBody(_javaEnv) { _javaEnv in
-            try String.toJava(
-                "\(Bytes.fromJava(_javaThis, env: _javaEnv))",
-                env: _javaEnv
-            )
-        }
+        try body(&Box<Bytes>.fromJava(this, env: env).value)
     }
 }

--- a/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/Collections+java.swift
+++ b/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/Collections+java.swift
@@ -6,43 +6,20 @@ import TestAPI
 
 extension Collections: JavaMutator {
     public static var javaClass: jclass?
-    private static var _refFieldID: jfieldID!
     private static var _constructorMethodID: jmethodID!
     public static func fromJava(_ value: jobject?, env: Env) throws -> Self {
-        let longRef = UInt(env.GetLongField(value, _refFieldID))
-        return try Box<Collections>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value
-    }
-    static let _javaFinalizer: @convention(c)(
-        UnsafeMutablePointer<JNIEnv?>,
-        jobject
-    ) -> Void = { env, this in
-        FishyJoesJavaRuntime.callbackBody(env) { env in
-            let longRef = UInt(env.GetLongField(this, _refFieldID))
-            Box<Collections>.releaseOpaque(try javaNonNull(UnsafeMutablePointer(bitPattern: longRef)))
-        }
+        try Box<Collections>.fromJava(value, env: env).value
     }
     public static func toJava(_ value: Self, env: Env) throws -> jobject? {
         let ptr = jvalue(j: jlong(UInt(bitPattern: Box(value).retainedOpaque())))
         return try env.NewObject(javaClass, _constructorMethodID, ptr)
     }
     public static func javaSetup(env: Env) throws {
+        try AnyBox.javaSetup(env: env)
         javaClass = try env.globalRef(env.FindClass("com/cricut/testapi/Collections"))
-        _refFieldID = try env.GetFieldID(javaClass, "_swiftReference", "J")
         _constructorMethodID = try env.GetMethodID(javaClass, "<init>", "(J)V")
     }
     public static func mutateJava<R>(_ this: jobject?, env: Env, body: (inout Self) throws -> R) throws -> R {
-        let longRef = UInt(env.GetLongField(this, _refFieldID))
-        return try body(&Box<Collections>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value)
-    }
-    static let _javaToString: @convention(c)(
-        UnsafeMutablePointer<JNIEnv?>,
-        jobject?
-    ) -> String.CType = { _javaEnv, _javaThis in
-        FishyJoesJavaRuntime.callbackBody(_javaEnv) { _javaEnv in
-            try String.toJava(
-                "\(Collections.fromJava(_javaThis, env: _javaEnv))",
-                env: _javaEnv
-            )
-        }
+        try body(&Box<Collections>.fromJava(this, env: env).value)
     }
 }

--- a/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/Primitives+java.swift
+++ b/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/Primitives+java.swift
@@ -6,43 +6,20 @@ import TestAPI
 
 extension Primitives: JavaMutator {
     public static var javaClass: jclass?
-    private static var _refFieldID: jfieldID!
     private static var _constructorMethodID: jmethodID!
     public static func fromJava(_ value: jobject?, env: Env) throws -> Self {
-        let longRef = UInt(env.GetLongField(value, _refFieldID))
-        return try Box<Primitives>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value
-    }
-    static let _javaFinalizer: @convention(c)(
-        UnsafeMutablePointer<JNIEnv?>,
-        jobject
-    ) -> Void = { env, this in
-        FishyJoesJavaRuntime.callbackBody(env) { env in
-            let longRef = UInt(env.GetLongField(this, _refFieldID))
-            Box<Primitives>.releaseOpaque(try javaNonNull(UnsafeMutablePointer(bitPattern: longRef)))
-        }
+        try Box<Primitives>.fromJava(value, env: env).value
     }
     public static func toJava(_ value: Self, env: Env) throws -> jobject? {
         let ptr = jvalue(j: jlong(UInt(bitPattern: Box(value).retainedOpaque())))
         return try env.NewObject(javaClass, _constructorMethodID, ptr)
     }
     public static func javaSetup(env: Env) throws {
+        try AnyBox.javaSetup(env: env)
         javaClass = try env.globalRef(env.FindClass("com/cricut/testapi/Primitives"))
-        _refFieldID = try env.GetFieldID(javaClass, "_swiftReference", "J")
         _constructorMethodID = try env.GetMethodID(javaClass, "<init>", "(J)V")
     }
     public static func mutateJava<R>(_ this: jobject?, env: Env, body: (inout Self) throws -> R) throws -> R {
-        let longRef = UInt(env.GetLongField(this, _refFieldID))
-        return try body(&Box<Primitives>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value)
-    }
-    static let _javaToString: @convention(c)(
-        UnsafeMutablePointer<JNIEnv?>,
-        jobject?
-    ) -> String.CType = { _javaEnv, _javaThis in
-        FishyJoesJavaRuntime.callbackBody(_javaEnv) { _javaEnv in
-            try String.toJava(
-                "\(Primitives.fromJava(_javaThis, env: _javaEnv))",
-                env: _javaEnv
-            )
-        }
+        try body(&Box<Primitives>.fromJava(this, env: env).value)
     }
 }

--- a/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/Strings+java.swift
+++ b/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/Strings+java.swift
@@ -6,43 +6,20 @@ import TestAPI
 
 extension Strings: JavaMutator {
     public static var javaClass: jclass?
-    private static var _refFieldID: jfieldID!
     private static var _constructorMethodID: jmethodID!
     public static func fromJava(_ value: jobject?, env: Env) throws -> Self {
-        let longRef = UInt(env.GetLongField(value, _refFieldID))
-        return try Box<Strings>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value
-    }
-    static let _javaFinalizer: @convention(c)(
-        UnsafeMutablePointer<JNIEnv?>,
-        jobject
-    ) -> Void = { env, this in
-        FishyJoesJavaRuntime.callbackBody(env) { env in
-            let longRef = UInt(env.GetLongField(this, _refFieldID))
-            Box<Strings>.releaseOpaque(try javaNonNull(UnsafeMutablePointer(bitPattern: longRef)))
-        }
+        try Box<Strings>.fromJava(value, env: env).value
     }
     public static func toJava(_ value: Self, env: Env) throws -> jobject? {
         let ptr = jvalue(j: jlong(UInt(bitPattern: Box(value).retainedOpaque())))
         return try env.NewObject(javaClass, _constructorMethodID, ptr)
     }
     public static func javaSetup(env: Env) throws {
+        try AnyBox.javaSetup(env: env)
         javaClass = try env.globalRef(env.FindClass("com/cricut/testapi/Strings"))
-        _refFieldID = try env.GetFieldID(javaClass, "_swiftReference", "J")
         _constructorMethodID = try env.GetMethodID(javaClass, "<init>", "(J)V")
     }
     public static func mutateJava<R>(_ this: jobject?, env: Env, body: (inout Self) throws -> R) throws -> R {
-        let longRef = UInt(env.GetLongField(this, _refFieldID))
-        return try body(&Box<Strings>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value)
-    }
-    static let _javaToString: @convention(c)(
-        UnsafeMutablePointer<JNIEnv?>,
-        jobject?
-    ) -> String.CType = { _javaEnv, _javaThis in
-        FishyJoesJavaRuntime.callbackBody(_javaEnv) { _javaEnv in
-            try String.toJava(
-                "\(Strings.fromJava(_javaThis, env: _javaEnv))",
-                env: _javaEnv
-            )
-        }
+        try body(&Box<Strings>.fromJava(this, env: env).value)
     }
 }

--- a/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/Structs+java.swift
+++ b/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/Structs+java.swift
@@ -6,43 +6,20 @@ import TestAPI
 
 extension Structs: JavaMutator {
     public static var javaClass: jclass?
-    private static var _refFieldID: jfieldID!
     private static var _constructorMethodID: jmethodID!
     public static func fromJava(_ value: jobject?, env: Env) throws -> Self {
-        let longRef = UInt(env.GetLongField(value, _refFieldID))
-        return try Box<Structs>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value
-    }
-    static let _javaFinalizer: @convention(c)(
-        UnsafeMutablePointer<JNIEnv?>,
-        jobject
-    ) -> Void = { env, this in
-        FishyJoesJavaRuntime.callbackBody(env) { env in
-            let longRef = UInt(env.GetLongField(this, _refFieldID))
-            Box<Structs>.releaseOpaque(try javaNonNull(UnsafeMutablePointer(bitPattern: longRef)))
-        }
+        try Box<Structs>.fromJava(value, env: env).value
     }
     public static func toJava(_ value: Self, env: Env) throws -> jobject? {
         let ptr = jvalue(j: jlong(UInt(bitPattern: Box(value).retainedOpaque())))
         return try env.NewObject(javaClass, _constructorMethodID, ptr)
     }
     public static func javaSetup(env: Env) throws {
+        try AnyBox.javaSetup(env: env)
         javaClass = try env.globalRef(env.FindClass("com/cricut/testapi/Structs"))
-        _refFieldID = try env.GetFieldID(javaClass, "_swiftReference", "J")
         _constructorMethodID = try env.GetMethodID(javaClass, "<init>", "(J)V")
     }
     public static func mutateJava<R>(_ this: jobject?, env: Env, body: (inout Self) throws -> R) throws -> R {
-        let longRef = UInt(env.GetLongField(this, _refFieldID))
-        return try body(&Box<Structs>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value)
-    }
-    static let _javaToString: @convention(c)(
-        UnsafeMutablePointer<JNIEnv?>,
-        jobject?
-    ) -> String.CType = { _javaEnv, _javaThis in
-        FishyJoesJavaRuntime.callbackBody(_javaEnv) { _javaEnv in
-            try String.toJava(
-                "\(Structs.fromJava(_javaThis, env: _javaEnv))",
-                env: _javaEnv
-            )
-        }
+        try body(&Box<Structs>.fromJava(this, env: env).value)
     }
 }

--- a/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/Structs.ReferenceStruct+java.swift
+++ b/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/Structs.ReferenceStruct+java.swift
@@ -6,33 +6,21 @@ import TestAPI
 
 extension Structs.ReferenceStruct: JavaMutator {
     public static var javaClass: jclass?
-    private static var _refFieldID: jfieldID!
     private static var _constructorMethodID: jmethodID!
     public static func fromJava(_ value: jobject?, env: Env) throws -> Self {
-        let longRef = UInt(env.GetLongField(value, _refFieldID))
-        return try Box<Structs.ReferenceStruct>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value
-    }
-    static let _javaFinalizer: @convention(c)(
-        UnsafeMutablePointer<JNIEnv?>,
-        jobject
-    ) -> Void = { env, this in
-        FishyJoesJavaRuntime.callbackBody(env) { env in
-            let longRef = UInt(env.GetLongField(this, _refFieldID))
-            Box<Structs.ReferenceStruct>.releaseOpaque(try javaNonNull(UnsafeMutablePointer(bitPattern: longRef)))
-        }
+        try Box<Structs.ReferenceStruct>.fromJava(value, env: env).value
     }
     public static func toJava(_ value: Self, env: Env) throws -> jobject? {
         let ptr = jvalue(j: jlong(UInt(bitPattern: Box(value).retainedOpaque())))
         return try env.NewObject(javaClass, _constructorMethodID, ptr)
     }
     public static func javaSetup(env: Env) throws {
+        try AnyBox.javaSetup(env: env)
         javaClass = try env.globalRef(env.FindClass("com/cricut/testapi/Structs$ReferenceStruct"))
-        _refFieldID = try env.GetFieldID(javaClass, "_swiftReference", "J")
         _constructorMethodID = try env.GetMethodID(javaClass, "<init>", "(J)V")
     }
     public static func mutateJava<R>(_ this: jobject?, env: Env, body: (inout Self) throws -> R) throws -> R {
-        let longRef = UInt(env.GetLongField(this, _refFieldID))
-        return try body(&Box<Structs.ReferenceStruct>.takeUnretainedOpaque(javaNonNull(UnsafeMutablePointer(bitPattern: longRef))).value)
+        try body(&Box<Structs.ReferenceStruct>.fromJava(this, env: env).value)
     }
     static let _javaEquals: @convention(c)(
         UnsafeMutablePointer<JNIEnv?>,
@@ -43,17 +31,6 @@ extension Structs.ReferenceStruct: JavaMutator {
         FishyJoesJavaRuntime.callbackBody(_javaEnv) { _javaEnv in
             return try Bool.toJava(
                 Structs.ReferenceStruct.fromJava(lhs, env: _javaEnv) == Structs.ReferenceStruct.fromJava(rhs, env: _javaEnv),
-                env: _javaEnv
-            )
-        }
-    }
-    static let _javaToString: @convention(c)(
-        UnsafeMutablePointer<JNIEnv?>,
-        jobject?
-    ) -> String.CType = { _javaEnv, _javaThis in
-        FishyJoesJavaRuntime.callbackBody(_javaEnv) { _javaEnv in
-            try String.toJava(
-                "\(Structs.ReferenceStruct.fromJava(_javaThis, env: _javaEnv))",
                 env: _javaEnv
             )
         }

--- a/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/TypeSetup.swift
+++ b/integration-tests/TestAPI-bindings/Sources/Generated/JavaInterface/TypeSetup.swift
@@ -139,16 +139,6 @@ public func JNIOnLoad(vm: UnsafeMutablePointer<JavaVM?>, reserved: UnsafeMutable
                 name: bag.add("__jni_get_data"),
                 signature: bag.add("()[B"),
                 fnPtr: unsafeBitCast(java_get_Bytes_data, to: UnsafeMutableRawPointer.self)
-            ),
-            JNINativeMethod(
-                name: bag.add("__jni_finalize"),
-                signature: bag.add("()V"),
-                fnPtr: unsafeBitCast(Bytes._javaFinalizer, to: UnsafeMutableRawPointer.self)
-            ),
-            JNINativeMethod(
-                name: bag.add("__jni_toString"),
-                signature: bag.add("()Ljava/lang/String;"),
-                fnPtr: unsafeBitCast(Bytes._javaToString, to: UnsafeMutableRawPointer.self)
             )
         )
         //print("setting up Collections.CollectionHolder...")
@@ -252,16 +242,6 @@ public func JNIOnLoad(vm: UnsafeMutablePointer<JavaVM?>, reserved: UnsafeMutable
                 name: bag.add("__jni_get_defaultCollectionHolder"),
                 signature: bag.add("()Lcom/cricut/testapi/Collections$CollectionHolder;"),
                 fnPtr: unsafeBitCast(java_get_Collections_defaultCollectionHolder, to: UnsafeMutableRawPointer.self)
-            ),
-            JNINativeMethod(
-                name: bag.add("__jni_finalize"),
-                signature: bag.add("()V"),
-                fnPtr: unsafeBitCast(Collections._javaFinalizer, to: UnsafeMutableRawPointer.self)
-            ),
-            JNINativeMethod(
-                name: bag.add("__jni_toString"),
-                signature: bag.add("()Ljava/lang/String;"),
-                fnPtr: unsafeBitCast(Collections._javaToString, to: UnsafeMutableRawPointer.self)
             )
         )
         //print("setting up Foundation.Data...")
@@ -710,16 +690,6 @@ public func JNIOnLoad(vm: UnsafeMutablePointer<JavaVM?>, reserved: UnsafeMutable
                 name: bag.add("__jni_get_defaultPrimitiveHolder"),
                 signature: bag.add("()Lcom/cricut/testapi/Primitives$PrimitiveHolder;"),
                 fnPtr: unsafeBitCast(java_get_Primitives_defaultPrimitiveHolder, to: UnsafeMutableRawPointer.self)
-            ),
-            JNINativeMethod(
-                name: bag.add("__jni_finalize"),
-                signature: bag.add("()V"),
-                fnPtr: unsafeBitCast(Primitives._javaFinalizer, to: UnsafeMutableRawPointer.self)
-            ),
-            JNINativeMethod(
-                name: bag.add("__jni_toString"),
-                signature: bag.add("()Ljava/lang/String;"),
-                fnPtr: unsafeBitCast(Primitives._javaToString, to: UnsafeMutableRawPointer.self)
             )
         )
         //print("setting up Structs.ReferenceStruct...")
@@ -741,17 +711,7 @@ public func JNIOnLoad(vm: UnsafeMutablePointer<JavaVM?>, reserved: UnsafeMutable
                 fnPtr: unsafeBitCast(java_get_Structs_ReferenceStruct_mutable, to: UnsafeMutableRawPointer.self)
             ),
             JNINativeMethod(
-                name: bag.add("__jni_finalize"),
-                signature: bag.add("()V"),
-                fnPtr: unsafeBitCast(Structs.ReferenceStruct._javaFinalizer, to: UnsafeMutableRawPointer.self)
-            ),
-            JNINativeMethod(
-                name: bag.add("__jni_toString"),
-                signature: bag.add("()Ljava/lang/String;"),
-                fnPtr: unsafeBitCast(Structs.ReferenceStruct._javaToString, to: UnsafeMutableRawPointer.self)
-            ),
-            JNINativeMethod(
-                name: bag.add("__jni__swiftEquals"),
+                name: bag.add("__jni_swiftEquals"),
                 signature: bag.add("(Lcom/cricut/testapi/Structs$ReferenceStruct;Lcom/cricut/testapi/Structs$ReferenceStruct;)Z"),
                 fnPtr: unsafeBitCast(Structs.ReferenceStruct._javaEquals, to: UnsafeMutableRawPointer.self)
             )
@@ -805,32 +765,10 @@ public func JNIOnLoad(vm: UnsafeMutablePointer<JavaVM?>, reserved: UnsafeMutable
                 name: bag.add("__jni_get_emojiMulti"),
                 signature: bag.add("()Ljava/lang/String;"),
                 fnPtr: unsafeBitCast(java_get_Strings_emojiMulti, to: UnsafeMutableRawPointer.self)
-            ),
-            JNINativeMethod(
-                name: bag.add("__jni_finalize"),
-                signature: bag.add("()V"),
-                fnPtr: unsafeBitCast(Strings._javaFinalizer, to: UnsafeMutableRawPointer.self)
-            ),
-            JNINativeMethod(
-                name: bag.add("__jni_toString"),
-                signature: bag.add("()Ljava/lang/String;"),
-                fnPtr: unsafeBitCast(Strings._javaToString, to: UnsafeMutableRawPointer.self)
             )
         )
         //print("setting up Structs...")
         try Structs.javaSetup(env: env)
-        try env.RegisterNatives(Structs.javaClass,
-            JNINativeMethod(
-                name: bag.add("__jni_finalize"),
-                signature: bag.add("()V"),
-                fnPtr: unsafeBitCast(Structs._javaFinalizer, to: UnsafeMutableRawPointer.self)
-            ),
-            JNINativeMethod(
-                name: bag.add("__jni_toString"),
-                signature: bag.add("()Ljava/lang/String;"),
-                fnPtr: unsafeBitCast(Structs._javaToString, to: UnsafeMutableRawPointer.self)
-            )
-        )
         //print("setting up UInt16...")
         try UInt16.javaSetup(env: env)
         //print("setting up UInt32...")

--- a/integration-tests/TestAPI-bindings/kotlin/.gitignore
+++ b/integration-tests/TestAPI-bindings/kotlin/.gitignore
@@ -33,14 +33,14 @@
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
-# .idea/artifacts
-# .idea/compiler.xml
-# .idea/jarRepositories.xml
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
+.idea/artifacts
+.idea/compiler.xml
+.idea/jarRepositories.xml
+.idea/modules.xml
+.idea/*.iml
+.idea/modules
+*.iml
+*.ipr
 
 # CMake
 cmake-build-*/

--- a/integration-tests/TestAPI-bindings/kotlin/.idea/compiler.xml
+++ b/integration-tests/TestAPI-bindings/kotlin/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="16" />
   </component>
 </project>

--- a/integration-tests/TestAPI-bindings/kotlin/.idea/jarRepositories.xml
+++ b/integration-tests/TestAPI-bindings/kotlin/.idea/jarRepositories.xml
@@ -24,7 +24,12 @@
     <remote-repository>
       <option name="id" value="MavenLocal" />
       <option name="name" value="MavenLocal" />
-      <option name="url" value="file:$USER_HOME$/.m2/repository/" />
+      <option name="url" value="file:$MAVEN_REPOSITORY$/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="GitHubPackagesSwiftRuntime" />
+      <option name="name" value="GitHubPackagesSwiftRuntime" />
+      <option name="url" value="https://maven.pkg.github.com/cricut/android-swift-runtime" />
     </remote-repository>
   </component>
 </project>

--- a/integration-tests/TestAPI-bindings/kotlin/.idea/misc.xml
+++ b/integration-tests/TestAPI-bindings/kotlin/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_16" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/integration-tests/TestAPI-bindings/kotlin/.idea/modules.xml
+++ b/integration-tests/TestAPI-bindings/kotlin/.idea/modules.xml
@@ -3,6 +3,8 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/kotlin.iml" filepath="$PROJECT_DIR$/.idea/modules/kotlin.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/kotlin.main.iml" filepath="$PROJECT_DIR$/.idea/modules/kotlin.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/kotlin.test.iml" filepath="$PROJECT_DIR$/.idea/modules/kotlin.test.iml" />
     </modules>
   </component>
 </project>

--- a/integration-tests/TestAPI-bindings/kotlin/.idea/modules/kotlin.iml
+++ b/integration-tests/TestAPI-bindings/kotlin/.idea/modules/kotlin.iml
@@ -1,72 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module external.linked.project.id="kotlin" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.cricut.TestAPI" external.system.module.version="0.0.1" type="JAVA_MODULE" version="4">
-  <component name="FacetManager">
-    <facet type="kotlin-language" name="Kotlin">
-      <configuration version="4" platform="JVM 1.8" allPlatforms="JVM [1.8]" useProjectSettings="false">
-        <compilerSettings>
-          <option name="additionalArguments" value="-Xallow-no-source-files" />
-        </compilerSettings>
-        <compilerArguments>
-          <option name="destination" value="$MODULE_DIR$/../../build/classes/kotlin/main" />
-          <option name="classpath" value="$USER_HOME$/.m2/repository/com/cricut/fishyjoes/runtime/0.1.3/runtime-0.1.3.jar:/Users/mstoker/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.5.21/2f537cad7e9eeb9da73738c8812e1e4cf9b62e4e/kotlin-stdlib-1.5.21.jar:/Users/mstoker/.gradle/caches/modules-2/files-2.1/org.jetbrains/annotations/13.0/919f0dfe192fb4e063e7dacadee7f8bb9a2672a9/annotations-13.0.jar:/Users/mstoker/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.5.21/cc8bf3586fd2ebcf234058b9440bb406e62dfacb/kotlin-stdlib-common-1.5.21.jar" />
-          <option name="noStdlib" value="true" />
-          <option name="noReflect" value="true" />
-          <option name="moduleName" value="kotlin" />
-          <option name="languageVersion" value="1.5" />
-          <option name="apiVersion" value="1.5" />
-          <option name="pluginOptions">
-            <array />
-          </option>
-          <option name="pluginClasspaths">
-            <array>
-              <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-script-runtime/1.5.21/96d49e89873fde985750af354b6eabb60cfa999b/kotlin-script-runtime-1.5.21.jar" />
-              <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-scripting-common/1.5.21/5d271f9e7e7191902f8c0d45c600f5b57a284036/kotlin-scripting-common-1.5.21.jar" />
-              <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-scripting-jvm/1.5.21/8143908a15163e634fecb87013ed4a139170b032/kotlin-scripting-jvm-1.5.21.jar" />
-              <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.5.21/cc8bf3586fd2ebcf234058b9440bb406e62dfacb/kotlin-stdlib-common-1.5.21.jar" />
-              <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.5.21/2f537cad7e9eeb9da73738c8812e1e4cf9b62e4e/kotlin-stdlib-1.5.21.jar" />
-              <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-core/1.3.8/f62be6d4cbf27781c2969867b4ed952f38378492/kotlinx-coroutines-core-1.3.8.jar" />
-              <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains/annotations/13.0/919f0dfe192fb4e063e7dacadee7f8bb9a2672a9/annotations-13.0.jar" />
-            </array>
-          </option>
-          <option name="errors">
-            <ArgumentParseErrors />
-          </option>
-        </compilerArguments>
-      </configuration>
-    </facet>
-  </component>
-  <component name="NewModuleRootManager">
-    <output url="file://$MODULE_DIR$/../../build/classes/java/main" />
-    <output-test url="file://$MODULE_DIR$/../../build/classes/java/test" />
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../..">
-      <sourceFolder url="file://$MODULE_DIR$/../../src/generated/kotlin" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../../src/generated/resources" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../../src/test/kotlin" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/../../.gradle" />
       <excludeFolder url="file://$MODULE_DIR$/../../build" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Gradle: com.cricut.fishyjoes:runtime:0.1.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:1.5.21" level="project" />
-    <orderEntry type="library" name="Gradle: org.jetbrains:annotations:13.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:1.5.21" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Gradle: com.cricut:android-swift-runtime:0.0.3" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.21" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.21" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:1.5.31" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:1.5.31" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.junit.platform:junit-platform-commons:1.8.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.junit.jupiter:junit-jupiter-api:5.8.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.opentest4j:opentest4j:1.2.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.apiguardian:apiguardian-api:1.1.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: com.cricut:android-swift-runtime:0.0.3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.21" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.21" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:1.5.31" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.junit.platform:junit-platform-engine:1.8.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.junit.jupiter:junit-jupiter-engine:5.8.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:1.5.31" level="project" />
   </component>
 </module>

--- a/integration-tests/TestAPI-bindings/kotlin/.idea/runConfigurations.xml
+++ b/integration-tests/TestAPI-bindings/kotlin/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/integration-tests/TestAPI-bindings/kotlin/.idea/vcs.xml
+++ b/integration-tests/TestAPI-bindings/kotlin/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+  </component>
+</project>

--- a/integration-tests/TestAPI-bindings/kotlin/build.gradle.kts
+++ b/integration-tests/TestAPI-bindings/kotlin/build.gradle.kts
@@ -10,13 +10,21 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        name = "GitHubPackagesFishyJoes"
-        url = uri("https://maven.pkg.github.com/cricut/FishyJoes")
+        name = "GitHubPackagesSwiftRuntime"
+        url = uri("https://maven.pkg.github.com/cricut/android-swift-runtime")
         credentials {
             username = if ((System.getenv("GITHUB_USER") ?: "") != "") System.getenv("GITHUB_USER") else project.property("gpr_user") as String
             password = if ((System.getenv("GITHUB_TOKEN") ?: "") != "") System.getenv("GITHUB_TOKEN") else project.property("gpr_key") as String
         }
     }
+//    maven {
+//        name = "GitHubPackagesFishyJoes"
+//        url = uri("https://maven.pkg.github.com/cricut/FishyJoes")
+//        credentials {
+//            username = if ((System.getenv("GITHUB_USER") ?: "") != "") System.getenv("GITHUB_USER") else project.property("gpr_user") as String
+//            password = if ((System.getenv("GITHUB_TOKEN") ?: "") != "") System.getenv("GITHUB_TOKEN") else project.property("gpr_key") as String
+//        }
+//    }
 }
 
 val sourcesJar by tasks.registering(Jar::class) {
@@ -90,7 +98,7 @@ tasks {
 
 dependencies {
     implementation(kotlin("stdlib:1.5.21"))
-    api("com.cricut.fishyjoes:runtime:0.2.2")
+    api("com.cricut.fishyjoes:runtime:local")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.0")
 }

--- a/integration-tests/TestAPI-bindings/kotlin/src/generated/kotlin/com/cricut/testapi/Bytes.kt
+++ b/integration-tests/TestAPI-bindings/kotlin/src/generated/kotlin/com/cricut/testapi/Bytes.kt
@@ -9,14 +9,6 @@ class Bytes private constructor(
     private val _swiftReference: Long
 )
  {
-    override fun toString(
-    ): String = __jni_toString()
-    @JvmName("__jni_toString")
-    private external fun __jni_toString(
-    ): String
-
-    protected fun finalize() = __jni_finalize()
-    private external fun __jni_finalize()
 
     companion object {
         /**

--- a/integration-tests/TestAPI-bindings/kotlin/src/generated/kotlin/com/cricut/testapi/Collections.kt
+++ b/integration-tests/TestAPI-bindings/kotlin/src/generated/kotlin/com/cricut/testapi/Collections.kt
@@ -9,14 +9,6 @@ class Collections private constructor(
     private val _swiftReference: Long
 )
  {
-    override fun toString(
-    ): String = __jni_toString()
-    @JvmName("__jni_toString")
-    private external fun __jni_toString(
-    ): String
-
-    protected fun finalize() = __jni_finalize()
-    private external fun __jni_finalize()
 
     companion object {
         /**

--- a/integration-tests/TestAPI-bindings/kotlin/src/generated/kotlin/com/cricut/testapi/Primitives.kt
+++ b/integration-tests/TestAPI-bindings/kotlin/src/generated/kotlin/com/cricut/testapi/Primitives.kt
@@ -9,14 +9,6 @@ class Primitives private constructor(
     private val _swiftReference: Long
 )
  {
-    override fun toString(
-    ): String = __jni_toString()
-    @JvmName("__jni_toString")
-    private external fun __jni_toString(
-    ): String
-
-    protected fun finalize() = __jni_finalize()
-    private external fun __jni_finalize()
 
     companion object {
         /**

--- a/integration-tests/TestAPI-bindings/kotlin/src/generated/kotlin/com/cricut/testapi/Strings.kt
+++ b/integration-tests/TestAPI-bindings/kotlin/src/generated/kotlin/com/cricut/testapi/Strings.kt
@@ -9,14 +9,6 @@ class Strings private constructor(
     private val _swiftReference: Long
 )
  {
-    override fun toString(
-    ): String = __jni_toString()
-    @JvmName("__jni_toString")
-    private external fun __jni_toString(
-    ): String
-
-    protected fun finalize() = __jni_finalize()
-    private external fun __jni_finalize()
 
     companion object {
         /**

--- a/integration-tests/TestAPI-bindings/kotlin/src/generated/kotlin/com/cricut/testapi/Structs.kt
+++ b/integration-tests/TestAPI-bindings/kotlin/src/generated/kotlin/com/cricut/testapi/Structs.kt
@@ -9,14 +9,6 @@ class Structs private constructor(
     private val _swiftReference: Long
 )
  {
-    override fun toString(
-    ): String = __jni_toString()
-    @JvmName("__jni_toString")
-    private external fun __jni_toString(
-    ): String
-
-    protected fun finalize() = __jni_finalize()
-    private external fun __jni_finalize()
 
     companion object {
         init {
@@ -55,16 +47,7 @@ class Structs private constructor(
 
         override fun equals(
             other: Any?
-        ): Boolean = (other is com.cricut.testapi.Structs.ReferenceStruct) && __jni__swiftEquals(this, other)
-
-        override fun toString(
-        ): String = __jni_toString()
-        @JvmName("__jni_toString")
-        private external fun __jni_toString(
-        ): String
-
-        protected fun finalize() = __jni_finalize()
-        private external fun __jni_finalize()
+        ): Boolean = (other is com.cricut.testapi.Structs.ReferenceStruct) && __jni_swiftEquals(this, other)
 
         companion object {
             /**
@@ -77,9 +60,13 @@ class Structs private constructor(
             private external fun __jni_create(
             ): com.cricut.testapi.Structs.ReferenceStruct
 
+            fun swiftEquals(
+                lhs: com.cricut.testapi.Structs.ReferenceStruct,
+                rhs: com.cricut.testapi.Structs.ReferenceStruct
+            ): Boolean = __jni_swiftEquals(lhs, rhs)
             @JvmStatic
-            @JvmName("__jni__swiftEquals")
-            private external fun __jni__swiftEquals(
+            @JvmName("__jni_swiftEquals")
+            private external fun __jni_swiftEquals(
                 lhs: com.cricut.testapi.Structs.ReferenceStruct,
                 rhs: com.cricut.testapi.Structs.ReferenceStruct
             ): Boolean

--- a/kotlin-runtime/gradle.properties
+++ b/kotlin-runtime/gradle.properties
@@ -1,5 +1,5 @@
 kotlin_version=1.3.61
 
 group=com.cricut.fishyjoes
-version=0.1.3
+version=local
 artifact=runtime

--- a/kotlin-runtime/src/main/kotlin/com/cricut/fishyjoes/runtime/SwiftReference.kt
+++ b/kotlin-runtime/src/main/kotlin/com/cricut/fishyjoes/runtime/SwiftReference.kt
@@ -1,0 +1,16 @@
+package com.cricut.fishyjoes.runtime
+
+abstract class SwiftReference protected constructor(private val swiftReference: Long) {
+    override fun hashCode(): Int = swiftReference.hashCode()
+    override fun toString(): String = swiftToString()
+    protected fun finalize() = swiftFinalize()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SwiftReference) return false
+        return swiftReference == other.swiftReference
+    }
+
+    private external fun swiftFinalize()
+    private external fun swiftToString(): String
+}

--- a/kotlin-runtime/src/test/kotlin/com/cricut/fishyjoes/runtime/TestFunction.kt
+++ b/kotlin-runtime/src/test/kotlin/com/cricut/fishyjoes/runtime/TestFunction.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 
-data class SwiftReference(var ref: Long) {
+data class TestReference(var ref: Long) {
     external fun append(x: Long)
     external fun addr(): Long
     external fun log()
@@ -34,7 +34,7 @@ internal class TestFunction {
 
     private external fun fun0(f: (Long, Long) -> Long): String
     private external fun fun1(): (Long, Long) -> Long
-    private external fun makeReference(): SwiftReference
+    private external fun makeReference(): TestReference
 
     companion object {
         @BeforeAll


### PR DESCRIPTION
Moving kotlin's swiftReference fields to a common superclass allows for code reuse between function types, generated reference types, and in the future protocol types.