### PR TITLE
fix names of shared objects in android lib install

### DIFF
--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -2,18 +2,6 @@ import ArgumentParser
 import Foundation
 import swsh
 
-let dylibExt: String = {
-    #if os(macOS)
-    "dylib"
-    #elseif os(Linux)
-    "so"
-    #elseif os(Windows)
-    "dll"
-    #else
-    fatalError("unknown host OS")
-    #endif
-}()
-
 public struct CodeGen: ParsableCommand {
     @Flag(name: .shortAndLong, help: "suppress verbose output")
     var quiet = false
@@ -260,8 +248,8 @@ extension CodeGen {
                 let outputDir = platform.outputDir(config)
 
                 func installLibrary(_ name: String, installName: String? = nil) throws {
-                    let src = "\(try platform.buildDir(configuration))/lib\(name).\(dylibExt)"
-                    let installName = installName ?? "lib\(name).\(dylibExt)"
+                    let src = "\(try platform.buildDir(configuration))/lib\(name).\(platform.dylibExt)"
+                    let installName = installName ?? "lib\(name).\(platform.dylibExt)"
                     let dest = "\(outputDir)/\(installName)"
                     try cmd("cp", src, dest).run()
                 }
@@ -346,7 +334,7 @@ extension CodeGen {
                         // For node to load a library correctly, the file must be ".cjs.node" and not a symlink
                         // But for the linker to find required libraries, they need their original names.
                         // So we symlink `libModule-node.dylib` -> `module.cjs.node`
-                        let compiledLibName = "lib\(dependency)-node.\(dylibExt)"
+                        let compiledLibName = "lib\(dependency)-node.\(platform.dylibExt)"
                         let nodeLibName = "\(dependency).cjs.node"
                         try installLibrary("\(dependency)-node", installName: nodeLibName)
                         try installLibrary(dependency)

--- a/Sources/FishyJoesExecute/Platform.swift
+++ b/Sources/FishyJoesExecute/Platform.swift
@@ -42,17 +42,15 @@ enum Platform: Hashable {
         case .kotlinAndroid:
             return "so"
         default:
-            if self  {
-                #if os(macOS)
-                return "dylib"
-                #elseif os(Linux)
-                return "so"
-                #elseif os(Windows)
-                return "dll"
-                #else
-                fatalError("unknown host OS")
-                #endif
-            }
+            #if os(macOS)
+            return "dylib"
+            #elseif os(Linux)
+            return "so"
+            #elseif os(Windows)
+            return "dll"
+            #else
+            fatalError("unknown host OS")
+            #endif
         }
     }
 

--- a/Sources/FishyJoesExecute/Platform.swift
+++ b/Sources/FishyJoesExecute/Platform.swift
@@ -26,15 +26,37 @@ enum Platform: Hashable {
         "-Xswiftc", "-profile-generate",
     ]
 
-    func build(product: String? = nil, libs: [String] = [], configuration: BuildConfiguration) throws {
-        let isNative: Bool
+    var isNative: Bool {
         switch self {
         case .wasm, .kotlinAndroid:
-            isNative = false
+            return false
         case .node, .cpp, .kotlinSystem, .cSharp:
-            isNative = true
+            return true
         }
+    }
 
+    var dylibExt: String {
+        switch self {
+        case .wasm:
+            return "wasmlib" // not a real thing
+        case .kotlinAndroid:
+            return "so"
+        default:
+            if self  {
+                #if os(macOS)
+                return "dylib"
+                #elseif os(Linux)
+                return "so"
+                #elseif os(Windows)
+                return "dll"
+                #else
+                fatalError("unknown host OS")
+                #endif
+            }
+        }
+    }
+
+    func build(product: String? = nil, libs: [String] = [], configuration: BuildConfiguration) throws {
         if isNative, configuration.fat {
             guard let product = product else {
                 fatalError("Can't infer products in fat builds")
@@ -210,7 +232,7 @@ enum Platform: Hashable {
     }
 
     func buildDir(_ configuration: BuildConfiguration) throws -> String {
-        if configuration.fat {
+        if isNative, configuration.fat {
             return ".build/apple/\(configuration.debug ? "debug" : "release")"
         } else {
             return try swiftBuild("--show-bin-path", configuration: configuration).runString()


### PR DESCRIPTION
FishyJoes was copying apple dylibs into android install locations due to too aggressive refactoring of the build script