### PR TITLE
feat: update swift-wasm toolchain version

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -23,7 +23,7 @@ jobs:
       GITHUB_USER: cricut-builduser
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SWIFT_WASM_URL: |-
-        https://github.com/swiftwasm/swift/releases/download/swift-wasm-5.6.0-RELEASE/swift-wasm-5.6.0-RELEASE-macos_x86_64.pkg
+        https://github.com/swiftwasm/swift/releases/download/swift-wasm-5.7.1-RELEASE/swift-wasm-5.7.1-RELEASE-macos_x86_64.pkg
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -86,7 +86,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CRICUT_GPR_TOKEN }}
       GITHUB_USER: cricut-builduser
       SWIFT_WASM_URL: |-
-        https://github.com/swiftwasm/swift/releases/download/swift-wasm-5.6.0-RELEASE/swift-wasm-5.6.0-RELEASE-ubuntu20.04_x86_64.tar.gz
+        https://github.com/swiftwasm/swift/releases/download/swift-wasm-5.7.1-RELEASE/swift-wasm-5.7.1-RELEASE-ubuntu20.04_x86_64.tar.gz
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -126,8 +126,8 @@ jobs:
           npm -g install binaryen@111.0.0
 
           curl -Lo swift-wasm.tgz $SWIFT_WASM_URL
-          sudo mkdir -p /Library/Developer/Toolchains/swift-wasm-5.6.0-RELEASE.xctoolchain
-          sudo tar -xf swift-wasm.tgz -C /Library/Developer/Toolchains/swift-wasm-5.6.0-RELEASE.xctoolchain --strip-components 1
+          sudo mkdir -p /Library/Developer/Toolchains/swift-wasm-5.7.1-RELEASE.xctoolchain
+          sudo tar -xf swift-wasm.tgz -C /Library/Developer/Toolchains/swift-wasm-5.7.1-RELEASE.xctoolchain --strip-components 1
 
       - name: Test from dotnet
         shell: zsh {0}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Build & test
     env:
       SWIFT_WASM_URL: |-
-        https://github.com/swiftwasm/swift/releases/download/swift-wasm-5.6.0-RELEASE/swift-wasm-5.6.0-RELEASE-macos_x86_64.pkg
+        https://github.com/swiftwasm/swift/releases/download/swift-wasm-5.7.1-RELEASE/swift-wasm-5.7.1-RELEASE-macos_x86_64.pkg
     runs-on: macOS-12
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ brew install openjdk@11 mint npm
 
 Install swift-wasm toolchain:
 ```
-curl -Lo swift-wasm.pkg https://github.com/swiftwasm/swift/releases/download/swift-wasm-5.6.0-RELEASE/swift-wasm-5.6.0-RELEASE-macos_x86_64.pkg
+curl -Lo swift-wasm.pkg https://github.com/swiftwasm/swift/releases/download/swift-wasm-5.7.1-RELEASE/swift-wasm-5.7.1-RELEASE-macos_x86_64.pkg
 sudo installer -pkg swift-wasm.pkg -target /
 ```
 

--- a/Sources/FishyJoesExecute/Platform.swift
+++ b/Sources/FishyJoesExecute/Platform.swift
@@ -1,7 +1,7 @@
 import Foundation
 import swsh
 
-let wasmToolchain = "/Library/Developer/Toolchains/swift-wasm-5.6.0-RELEASE.xctoolchain"
+let wasmToolchain = "/Library/Developer/Toolchains/swift-wasm-5.7.1-RELEASE.xctoolchain"
 
 struct BuildConfiguration {
     let debug: Bool

--- a/Sources/FishyJoesExecute/Resources/bindings-template/.github/workflows/typescript.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/.github/workflows/typescript.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   NODE_VERSION: "16.x"
-  SWIFT_WASM_VERSION: "5.6.0-RELEASE"
+  SWIFT_WASM_VERSION: "5.7.1-RELEASE"
 
 jobs:
   build-test-pack-ts-mac:

--- a/Tests/NAPITests/NAPITests.swift
+++ b/Tests/NAPITests/NAPITests.swift
@@ -8,7 +8,7 @@ class NAPITests: XCTestCase {
     let LD = "/Library/Developer/Toolchains/swift-wasm-5.7.1-RELEASE.xctoolchain/usr/bin/swiftc"
     let CFLAGS = [
         "-target", "wasm32-unknown-wasi",
-        "--sysroot", "/Library/Developer/Toolchains/swift-wasm-5.6.0-RELEASE.xctoolchain/usr/share/wasi-sysroot",
+        "--sysroot", "/Library/Developer/Toolchains/swift-wasm-5.7.1-RELEASE.xctoolchain/usr/share/wasi-sysroot",
         "-I/opt/homebrew/include/node",
         "-I/usr/local/include/node",
     ]

--- a/Tests/NAPITests/NAPITests.swift
+++ b/Tests/NAPITests/NAPITests.swift
@@ -4,8 +4,8 @@ import XCTest
 
 class NAPITests: XCTestCase {
     lazy var testDirectory = "Tests/NAPITests/node-tests/js-native-api"
-    let CC = "/Library/Developer/Toolchains/swift-wasm-5.6.0-RELEASE.xctoolchain/usr/bin/clang"
-    let LD = "/Library/Developer/Toolchains/swift-wasm-5.6.0-RELEASE.xctoolchain/usr/bin/swiftc"
+    let CC = "/Library/Developer/Toolchains/swift-wasm-5.7.1-RELEASE.xctoolchain/usr/bin/clang"
+    let LD = "/Library/Developer/Toolchains/swift-wasm-5.7.1-RELEASE.xctoolchain/usr/bin/swiftc"
     let CFLAGS = [
         "-target", "wasm32-unknown-wasi",
         "--sysroot", "/Library/Developer/Toolchains/swift-wasm-5.6.0-RELEASE.xctoolchain/usr/share/wasi-sysroot",
@@ -13,8 +13,8 @@ class NAPITests: XCTestCase {
         "-I/usr/local/include/node",
     ]
     let LDFLAGS = [
-        "-L/Library/Developer/Toolchains/swift-wasm-5.6.0-RELEASE.xctoolchain/usr/lib",
-        "-sdk", "/Library/Developer/Toolchains/swift-wasm-5.6.0-RELEASE.xctoolchain/usr/share/wasi-sysroot",
+        "-L/Library/Developer/Toolchains/swift-wasm-5.7.1-RELEASE.xctoolchain/usr/lib",
+        "-sdk", "/Library/Developer/Toolchains/swift-wasm-5.7.1-RELEASE.xctoolchain/usr/share/wasi-sysroot",
         "-lswiftCore",
         "-emit-executable",
         "-target", "wasm32-unknown-wasi",


### PR DESCRIPTION
fixes issue found in criraster with callback functions, optionals, and wacky wasm files that error on load