### PR TITLE
Stamp runtime package with NDK version

### DIFF
--- a/scripts/compile-android-runtime.sh
+++ b/scripts/compile-android-runtime.sh
@@ -28,3 +28,5 @@ for platformStr in $androidsStupidPlatforms; do
     mkdir -p $installDir/
     cp .build/$arch-unknown-linux-android$androidAPIVersion/release/libFishyJoesJavaRuntime.so $installDir/
 done
+
+cp /VERSIONS $libdir/FishyJoesAndroidVersions.txt


### PR DESCRIPTION
puts version info in the root of the runtime jar as a text file:

```
$ tar xf ~/.m2/repository/com/cricut/fishyjoes/runtime/local/runtime-local.jar FishyJoesAndroidVersions.txt
$ cat FishyJoesAndroidVersions.txt
androidArchs=(aarch64 armv7 x86_64)
swiftVersion=5.7.1
androidAPIVersion=24
ndkVersion=25.1.8937393
```