### PR TITLE
fix: add missing runtime extensions

### DIFF
--- a/integration-tests/TestAPI-bindings/node-test/Extensions.test.ts
+++ b/integration-tests/TestAPI-bindings/node-test/Extensions.test.ts
@@ -1,7 +1,12 @@
-import { TestAPI } from 'TestAPI';
+import { Runtime, TestAPI } from 'TestAPI';
 
 test('testExtensions', () => {
     expect(new TestAPI.String_PuttingTypesIntoQuestionablePlaces("").testCall()).toEqual(42)
     expect(TestAPI.Structs_PuttingTypesIntoQuestionablePlaces.create().testCall()).toEqual(43)
     expect(TestAPI.UnicodeScalar_PuttingTypesIntoQuestionablePlaces.testCall("thing")).toEqual(44)
+    
+    const attributedString = Runtime.AttributedString.create(`foo bar baz`);
+    expect(attributedString.characters.forEach).toBeDefined();
+    expect(attributedString.unicodeScalars.forEach).toBeDefined();
+    expect(attributedString.runs.forEach).toBeDefined();
 });

--- a/node-runtime/fishyjoes-runtime-common/Runtime.extensions.js
+++ b/node-runtime/fishyjoes-runtime-common/Runtime.extensions.js
@@ -29,6 +29,10 @@ function applyExtensions(library) {
             index = this.indexAfter(index)
         }
     }
+    
+    library.Runtime.AttributedString.Runs.prototype.forEach = function(callback) {
+        [...this].forEach(callback)
+    }
 
     library.Runtime.AttributedString.CharacterView.prototype[Symbol.iterator] = function* () {
         let index = this.startIndex;
@@ -37,6 +41,10 @@ function applyExtensions(library) {
             index = this.indexAfter(index)
         }
     }
+    
+    library.Runtime.AttributedString.CharacterView.prototype.forEach = function(callback) {
+        [...this].forEach(callback)
+    }
 
     library.Runtime.AttributedString.UnicodeScalarView.prototype[Symbol.iterator] = function* () {
         let index = this.startIndex;
@@ -44,6 +52,10 @@ function applyExtensions(library) {
             yield this.elementAt(index)
             index = this.indexAfter(index)
         }
+    }
+    
+    library.Runtime.AttributedString.UnicodeScalarView.prototype.forEach = function(callback) {
+        [...this].forEach(callback)
     }
 }
 const imports = {};


### PR DESCRIPTION
forEach was present in the typings but not implemented, causing runtime errors in js