### PR TITLE
AB#426027 Put in toString, shallowCopy, and test for hashCode on dart sealed class enums

### DIFF
--- a/Sources/FishyJoesCore/Unparse/DartClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartClass.swift
@@ -699,9 +699,11 @@ class DartEnumClass: DartClass {
                         fragment.blankLine()
                     } else {
                         fragment.output(" &&")
-                        fragment.outputMap(enumCase.values, separator: " &&") { value in
-                            let valueName = "\(DartClass.deforbidify(value.name))"
-                            return "(identical(other.\(valueName), \(valueName)) || other.\(valueName) == \(valueName))"
+                        fragment.outputBlock("(") {
+                            fragment.outputMap(enumCase.values, separator: " &&") { value in
+                                let valueName = "\(DartClass.deforbidify(value.name))"
+                                return "const DeepCollectionEquality().equals(other.\(valueName), \(valueName))"
+                            }
                         }
                     }
                     fragment.currentIndent -= 1
@@ -720,7 +722,7 @@ class DartEnumClass: DartClass {
                     fragment.currentIndent += 1
                     fragment.output("runtimeType,")
                     fragment.outputMap(enumCase.values, separator: ", ") { value in
-                        "\(DartClass.deforbidify(value.name))"
+                        "const DeepCollectionEquality().hash(\(DartClass.deforbidify(value.name)))"
                     }
                     fragment.currentIndent -= 1
                     fragment.output(");")
@@ -736,10 +738,13 @@ class DartEnumClass: DartClass {
                 fragment.blankLine()
 
                 fragment.output("@override")
-                fragment.output("\(unqualifiedName) shallowCopy() => ", newLineTerminated: false)
-                fragment.output("\(unqualifiedName).\(enumCase.name)(", newLineTerminated: false)
-                let shallowCopyParamsString = enumCase.values.map { DartClass.deforbidify($0.name) }.joined(separator: ", ")
-                fragment.output("\(shallowCopyParamsString));")
+                fragment.output("\(unqualifiedName) shallowCopy() => \(unqualifiedName).\(enumCase.name)", newLineTerminated: false)
+                fragment.outputBlock(" (", newLineTerminated: false) {
+                    fragment.outputMap(enumCase.values, separator: ", ") {
+                        "\(DartClass.deforbidify($0.name))"
+                    }
+                }
+                fragment.output(";")
             }
 
             fragment.blankLine()

--- a/Sources/FishyJoesCore/Unparse/DartClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartClass.swift
@@ -729,27 +729,17 @@ class DartEnumClass: DartClass {
                 fragment.blankLine()
 
                 fragment.output("@override")
-                fragment.output("String toString()", newLineTerminated: false)
-                fragment.outputBlock(" {") {
-                    fragment.output("return '\(unqualifiedName).\(enumCase.name)(", newLineTerminated: false)
-                    var paramsString = String()
-                    for (index, value) in enumCase.values.enumerated() {
-                        let valueString = "\(DartClass.deforbidify(value.name))"
-                        paramsString += "\(valueString): $\(valueString)"
-                        if index < enumCase.values.indices.upperBound - 1 {
-                            paramsString += ", "
-                        }
-                    }
-                    fragment.output("\(paramsString))';")
-                }
+                fragment.output("String toString() => '\(unqualifiedName).\(enumCase.name)(", newLineTerminated: false)
+                let toStringParamsString = enumCase.values.map { "\(DartClass.deforbidify($0.name)): $\(DartClass.deforbidify($0.name))" }.joined(separator: ", ")
+                fragment.output("\(toStringParamsString))';")
 
                 fragment.blankLine()
 
                 fragment.output("@override")
                 fragment.output("\(unqualifiedName) shallowCopy() => ", newLineTerminated: false)
                 fragment.output("\(unqualifiedName).\(enumCase.name)(", newLineTerminated: false)
-                let paramsString = enumCase.values.map { DartClass.deforbidify($0.name) }.joined(separator: ", ")
-                fragment.output("\(paramsString));")
+                let shallowCopyParamsString = enumCase.values.map { DartClass.deforbidify($0.name) }.joined(separator: ", ")
+                fragment.output("\(shallowCopyParamsString));")
             }
 
             fragment.blankLine()

--- a/Sources/FishyJoesCore/Unparse/DartClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartClass.swift
@@ -655,10 +655,7 @@ class DartEnumClass: DartClass {
 
             fragment.blankLine()
 
-            fragment.output("\(unqualifiedName) shallowCopy()", newLineTerminated: false)
-            fragment.outputBlock(" {") {
-                fragment.output("throw UnsupportedError('\(unqualifiedName) shallowCopy() must be overridden by a subclass.');")
-            }
+            fragment.output("\(unqualifiedName) shallowCopy() => throw UnsupportedError('\(unqualifiedName) shallowCopy() must be overridden by a subclass.');")
         }
 
         fragment.blankLine()
@@ -749,19 +746,17 @@ class DartEnumClass: DartClass {
                 fragment.blankLine()
 
                 fragment.output("@override")
-                fragment.output("\(unqualifiedName) shallowCopy()", newLineTerminated: false)
-                fragment.outputBlock(" {") {
-                    fragment.output("return \(unqualifiedName).\(enumCase.name)(", newLineTerminated: false)
-                    var paramsString = String()
-                    for (index, value) in enumCase.values.enumerated() {
-                        let valueString = "\(DartClass.deforbidify(value.name))"
-                        paramsString += "\(valueString)"
-                        if index < enumCase.values.indices.upperBound - 1 {
-                            paramsString += ", "
-                        }
+                fragment.output("\(unqualifiedName) shallowCopy() => ", newLineTerminated: false)
+                fragment.output("\(unqualifiedName).\(enumCase.name)(", newLineTerminated: false)
+                var paramsString = String()
+                for (index, value) in enumCase.values.enumerated() {
+                    let valueString = "\(DartClass.deforbidify(value.name))"
+                    paramsString += "\(valueString)"
+                    if index < enumCase.values.indices.upperBound - 1 {
+                        paramsString += ", "
                     }
-                    fragment.output("\(paramsString));")
                 }
+                fragment.output("\(paramsString));")
             }
 
             fragment.blankLine()

--- a/Sources/FishyJoesCore/Unparse/DartClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartClass.swift
@@ -720,6 +720,23 @@ class DartEnumClass: DartClass {
                     fragment.currentIndent -= 1
                     fragment.output(");")
                 }
+                
+                fragment.blankLine()
+
+                fragment.output("@override")
+                fragment.output("String toString()", newLineTerminated: false)
+                fragment.outputBlock(" {") {
+                    fragment.output("return '\(unqualifiedName).\(enumCase.name)(", newLineTerminated: false)
+                    var paramsString = String()
+                    for (index, value) in enumCase.values.enumerated() {
+                        let valueString = "\(DartClass.deforbidify(value.name))"
+                        paramsString += "\(valueString): $\(valueString)"
+                        if index < enumCase.values.indices.upperBound - 1 {
+                            paramsString += ", "
+                        }
+                    }
+                    fragment.output("\(paramsString))';")
+                }
             }
 
             fragment.blankLine()

--- a/Sources/FishyJoesCore/Unparse/DartClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartClass.swift
@@ -677,15 +677,15 @@ class DartEnumClass: DartClass {
                     }
                 }
                 fragment.output(";")
-
+                
                 fragment.blankLine()
-
+                
                 for value in enumCase.values {
                     fragment.output("final \(value.type.name(in: self)) \(DartClass.deforbidify(value.name));")
                 }
-
+                
                 fragment.blankLine()
-
+                
                 fragment.output("@override")
                 fragment.output("bool operator ==(Object other)", newLineTerminated: false)
                 fragment.outputBlock(" {") {
@@ -694,7 +694,7 @@ class DartEnumClass: DartClass {
                     fragment.currentIndent += 1
                     fragment.output("other.runtimeType == runtimeType &&")
                     fragment.output("other is \(className)", newLineTerminated: false)
-
+                    
                     if enumCase.values.isEmpty {
                         fragment.blankLine()
                     } else {
@@ -709,10 +709,10 @@ class DartEnumClass: DartClass {
                     fragment.currentIndent -= 1
                     fragment.output(");")
                 }
-
+                
                 fragment.blankLine()
                 fragment.blankLine()
-
+                
                 fragment.output("@override")
                 fragment.output("int get hashCode => ", newLineTerminated: false)
                 if enumCase.values.isEmpty {
@@ -727,24 +727,29 @@ class DartEnumClass: DartClass {
                     fragment.currentIndent -= 1
                     fragment.output(");")
                 }
-
+                
                 fragment.blankLine()
-
+                
                 fragment.output("@override")
                 fragment.output("String toString() => '\(unqualifiedName).\(enumCase.name)(", newLineTerminated: false)
                 let toStringParamsString = enumCase.values.map { "\(DartClass.deforbidify($0.name)): $\(DartClass.deforbidify($0.name))" }.joined(separator: ", ")
                 fragment.output("\(toStringParamsString))';")
-
+                
                 fragment.blankLine()
-
+                
                 fragment.output("@override")
                 fragment.output("\(unqualifiedName) shallowCopy() => \(unqualifiedName).\(enumCase.name)", newLineTerminated: false)
-                fragment.outputBlock(" (", newLineTerminated: false) {
-                    fragment.outputMap(enumCase.values, separator: ", ") {
-                        "\(DartClass.deforbidify($0.name))"
+                if !enumCase.values.isEmpty {
+                    fragment.outputBlock(" (", newLineTerminated: false) {
+                        
+                        fragment.outputMap(enumCase.values, separator: ", ") {
+                            "\(DartClass.deforbidify($0.name))"
+                        }
                     }
+                    fragment.output(";")
+                } else {
+                    fragment.output("();")
                 }
-                fragment.output(";")
             }
 
             fragment.blankLine()

--- a/Sources/FishyJoesCore/Unparse/DartClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartClass.swift
@@ -652,9 +652,9 @@ class DartEnumClass: DartClass {
             fragment.blankLine()
 
             outputNativeMethodDeclarations(to: fragment)
-            
+
             fragment.blankLine()
-            
+
             fragment.output("\(unqualifiedName) shallowCopy()", newLineTerminated: false)
             fragment.outputBlock(" {") {
                 fragment.output("throw UnsupportedError('\(unqualifiedName) shallowCopy() must be overridden by a subclass.');")
@@ -728,7 +728,7 @@ class DartEnumClass: DartClass {
                     fragment.currentIndent -= 1
                     fragment.output(");")
                 }
-                
+
                 fragment.blankLine()
 
                 fragment.output("@override")
@@ -745,9 +745,9 @@ class DartEnumClass: DartClass {
                     }
                     fragment.output("\(paramsString))';")
                 }
-                
+
                 fragment.blankLine()
-                
+
                 fragment.output("@override")
                 fragment.output("\(unqualifiedName) shallowCopy()", newLineTerminated: false)
                 fragment.outputBlock(" {") {
@@ -760,7 +760,7 @@ class DartEnumClass: DartClass {
                             paramsString += ", "
                         }
                     }
-                    fragment.output("\(paramsString));");
+                    fragment.output("\(paramsString));")
                 }
             }
 

--- a/Sources/FishyJoesCore/Unparse/DartClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartClass.swift
@@ -650,7 +650,15 @@ class DartEnumClass: DartClass {
             methods.forEach { output(method: $0, to: fragment) }
 
             fragment.blankLine()
+
             outputNativeMethodDeclarations(to: fragment)
+            
+            fragment.blankLine()
+            
+            fragment.output("\(unqualifiedName) shallowCopy()", newLineTerminated: false)
+            fragment.outputBlock(" {") {
+                fragment.output("throw UnsupportedError('\(unqualifiedName) shallowCopy() must be overridden by a subclass.');")
+            }
         }
 
         fragment.blankLine()
@@ -736,6 +744,23 @@ class DartEnumClass: DartClass {
                         }
                     }
                     fragment.output("\(paramsString))';")
+                }
+                
+                fragment.blankLine()
+                
+                fragment.output("@override")
+                fragment.output("\(unqualifiedName) shallowCopy()", newLineTerminated: false)
+                fragment.outputBlock(" {") {
+                    fragment.output("return \(unqualifiedName).\(enumCase.name)(", newLineTerminated: false)
+                    var paramsString = String()
+                    for (index, value) in enumCase.values.enumerated() {
+                        let valueString = "\(DartClass.deforbidify(value.name))"
+                        paramsString += "\(valueString)"
+                        if index < enumCase.values.indices.upperBound - 1 {
+                            paramsString += ", "
+                        }
+                    }
+                    fragment.output("\(paramsString));");
                 }
             }
 

--- a/Sources/FishyJoesCore/Unparse/DartClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartClass.swift
@@ -748,14 +748,7 @@ class DartEnumClass: DartClass {
                 fragment.output("@override")
                 fragment.output("\(unqualifiedName) shallowCopy() => ", newLineTerminated: false)
                 fragment.output("\(unqualifiedName).\(enumCase.name)(", newLineTerminated: false)
-                var paramsString = String()
-                for (index, value) in enumCase.values.enumerated() {
-                    let valueString = "\(DartClass.deforbidify(value.name))"
-                    paramsString += "\(valueString)"
-                    if index < enumCase.values.indices.upperBound - 1 {
-                        paramsString += ", "
-                    }
-                }
+                let paramsString = enumCase.values.map { DartClass.deforbidify($0.name) }.joined(separator: ", ")
                 fragment.output("\(paramsString));")
             }
 

--- a/Sources/FishyJoesCore/Unparse/DartClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartClass.swift
@@ -677,15 +677,15 @@ class DartEnumClass: DartClass {
                     }
                 }
                 fragment.output(";")
-                
+
                 fragment.blankLine()
-                
+
                 for value in enumCase.values {
                     fragment.output("final \(value.type.name(in: self)) \(DartClass.deforbidify(value.name));")
                 }
-                
+
                 fragment.blankLine()
-                
+
                 fragment.output("@override")
                 fragment.output("bool operator ==(Object other)", newLineTerminated: false)
                 fragment.outputBlock(" {") {
@@ -694,7 +694,7 @@ class DartEnumClass: DartClass {
                     fragment.currentIndent += 1
                     fragment.output("other.runtimeType == runtimeType &&")
                     fragment.output("other is \(className)", newLineTerminated: false)
-                    
+
                     if enumCase.values.isEmpty {
                         fragment.blankLine()
                     } else {
@@ -709,10 +709,10 @@ class DartEnumClass: DartClass {
                     fragment.currentIndent -= 1
                     fragment.output(");")
                 }
-                
+
                 fragment.blankLine()
                 fragment.blankLine()
-                
+
                 fragment.output("@override")
                 fragment.output("int get hashCode => ", newLineTerminated: false)
                 if enumCase.values.isEmpty {
@@ -727,21 +727,20 @@ class DartEnumClass: DartClass {
                     fragment.currentIndent -= 1
                     fragment.output(");")
                 }
-                
+
                 fragment.blankLine()
-                
+
                 fragment.output("@override")
                 fragment.output("String toString() => '\(unqualifiedName).\(enumCase.name)(", newLineTerminated: false)
                 let toStringParamsString = enumCase.values.map { "\(DartClass.deforbidify($0.name)): $\(DartClass.deforbidify($0.name))" }.joined(separator: ", ")
                 fragment.output("\(toStringParamsString))';")
-                
+
                 fragment.blankLine()
-                
+
                 fragment.output("@override")
                 fragment.output("\(unqualifiedName) shallowCopy() => \(unqualifiedName).\(enumCase.name)", newLineTerminated: false)
                 if !enumCase.values.isEmpty {
                     fragment.outputBlock(" (", newLineTerminated: false) {
-                        
                         fragment.outputMap(enumCase.values, separator: ", ") {
                             "\(DartClass.deforbidify($0.name))"
                         }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/AssociatedDataEnum.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/AssociatedDataEnum.dart
@@ -255,21 +255,25 @@ class AssociatedDataEnum_Thing extends AssociatedDataEnum {
         (
             other.runtimeType == runtimeType &&
             other is AssociatedDataEnum_Thing &&
-            (identical(other.value, value) || other.value == value)
+            (
+                const DeepCollectionEquality().equals(other.value, value)
+            )
         );
     }
 
     @override
     int get hashCode => Object.hash(
         runtimeType,
-        value
+        const DeepCollectionEquality().hash(value)
     );
 
     @override
     String toString() => 'AssociatedDataEnum.thing(value: $value)';
 
     @override
-    AssociatedDataEnum shallowCopy() => AssociatedDataEnum.thing(value);
+    AssociatedDataEnum shallowCopy() => AssociatedDataEnum.thing (
+        value
+    );
 }
 
 class AssociatedDataEnum_Other extends AssociatedDataEnum {
@@ -287,23 +291,28 @@ class AssociatedDataEnum_Other extends AssociatedDataEnum {
         (
             other.runtimeType == runtimeType &&
             other is AssociatedDataEnum_Other &&
-            (identical(other.unnamed, unnamed) || other.unnamed == unnamed) &&
-            (identical(other.m_1, m_1) || other.m_1 == m_1)
+            (
+                const DeepCollectionEquality().equals(other.unnamed, unnamed) &&
+                const DeepCollectionEquality().equals(other.m_1, m_1)
+            )
         );
     }
 
     @override
     int get hashCode => Object.hash(
         runtimeType,
-        unnamed, 
-        m_1
+        const DeepCollectionEquality().hash(unnamed), 
+        const DeepCollectionEquality().hash(m_1)
     );
 
     @override
     String toString() => 'AssociatedDataEnum.other(unnamed: $unnamed, m_1: $m_1)';
 
     @override
-    AssociatedDataEnum shallowCopy() => AssociatedDataEnum.other(unnamed, m_1);
+    AssociatedDataEnum shallowCopy() => AssociatedDataEnum.other (
+        unnamed, 
+        m_1
+    );
 }
 
 class AssociatedDataEnum_Bar extends AssociatedDataEnum {
@@ -321,23 +330,28 @@ class AssociatedDataEnum_Bar extends AssociatedDataEnum {
         (
             other.runtimeType == runtimeType &&
             other is AssociatedDataEnum_Bar &&
-            (identical(other.named, named) || other.named == named) &&
-            (identical(other.m_1, m_1) || other.m_1 == m_1)
+            (
+                const DeepCollectionEquality().equals(other.named, named) &&
+                const DeepCollectionEquality().equals(other.m_1, m_1)
+            )
         );
     }
 
     @override
     int get hashCode => Object.hash(
         runtimeType,
-        named, 
-        m_1
+        const DeepCollectionEquality().hash(named), 
+        const DeepCollectionEquality().hash(m_1)
     );
 
     @override
     String toString() => 'AssociatedDataEnum.bar(named: $named, m_1: $m_1)';
 
     @override
-    AssociatedDataEnum shallowCopy() => AssociatedDataEnum.bar(named, m_1);
+    AssociatedDataEnum shallowCopy() => AssociatedDataEnum.bar (
+        named, 
+        m_1
+    );
 }
 
 class AssociatedDataEnum_NoValue extends AssociatedDataEnum {
@@ -375,19 +389,23 @@ class AssociatedDataEnum_SimpleEnum extends AssociatedDataEnum {
         (
             other.runtimeType == runtimeType &&
             other is AssociatedDataEnum_SimpleEnum &&
-            (identical(other.value, value) || other.value == value)
+            (
+                const DeepCollectionEquality().equals(other.value, value)
+            )
         );
     }
 
     @override
     int get hashCode => Object.hash(
         runtimeType,
-        value
+        const DeepCollectionEquality().hash(value)
     );
 
     @override
     String toString() => 'AssociatedDataEnum.simpleEnum(value: $value)';
 
     @override
-    AssociatedDataEnum shallowCopy() => AssociatedDataEnum.simpleEnum(value);
+    AssociatedDataEnum shallowCopy() => AssociatedDataEnum.simpleEnum (
+        value
+    );
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/AssociatedDataEnum.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/AssociatedDataEnum.dart
@@ -262,6 +262,11 @@ class AssociatedDataEnum_Thing extends AssociatedDataEnum {
         runtimeType,
         value
     );
+
+    @override
+    String toString() {
+        return 'AssociatedDataEnum.thing(value: $value)';
+    }
 }
 
 class AssociatedDataEnum_Other extends AssociatedDataEnum {
@@ -290,6 +295,11 @@ class AssociatedDataEnum_Other extends AssociatedDataEnum {
         unnamed, 
         m_1
     );
+
+    @override
+    String toString() {
+        return 'AssociatedDataEnum.other(unnamed: $unnamed, m_1: $m_1)';
+    }
 }
 
 class AssociatedDataEnum_Bar extends AssociatedDataEnum {
@@ -318,6 +328,11 @@ class AssociatedDataEnum_Bar extends AssociatedDataEnum {
         named, 
         m_1
     );
+
+    @override
+    String toString() {
+        return 'AssociatedDataEnum.bar(named: $named, m_1: $m_1)';
+    }
 }
 
 class AssociatedDataEnum_NoValue extends AssociatedDataEnum {
@@ -334,6 +349,11 @@ class AssociatedDataEnum_NoValue extends AssociatedDataEnum {
 
     @override
     int get hashCode => runtimeType.hashCode;
+
+    @override
+    String toString() {
+        return 'AssociatedDataEnum.noValue()';
+    }
 }
 
 class AssociatedDataEnum_SimpleEnum extends AssociatedDataEnum {
@@ -358,4 +378,9 @@ class AssociatedDataEnum_SimpleEnum extends AssociatedDataEnum {
         runtimeType,
         value
     );
+
+    @override
+    String toString() {
+        return 'AssociatedDataEnum.simpleEnum(value: $value)';
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/AssociatedDataEnum.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/AssociatedDataEnum.dart
@@ -239,9 +239,7 @@ sealed class AssociatedDataEnum {
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_AssociatedDataEnum_staticThing;
 
-    AssociatedDataEnum shallowCopy() {
-        throw UnsupportedError('AssociatedDataEnum shallowCopy() must be overridden by a subclass.');
-    }
+    AssociatedDataEnum shallowCopy() => throw UnsupportedError('AssociatedDataEnum shallowCopy() must be overridden by a subclass.');
 }
 
 class AssociatedDataEnum_Thing extends AssociatedDataEnum {
@@ -273,9 +271,7 @@ class AssociatedDataEnum_Thing extends AssociatedDataEnum {
     }
 
     @override
-    AssociatedDataEnum shallowCopy() {
-        return AssociatedDataEnum.thing(value);
-    }
+    AssociatedDataEnum shallowCopy() => AssociatedDataEnum.thing(value);
 }
 
 class AssociatedDataEnum_Other extends AssociatedDataEnum {
@@ -311,9 +307,7 @@ class AssociatedDataEnum_Other extends AssociatedDataEnum {
     }
 
     @override
-    AssociatedDataEnum shallowCopy() {
-        return AssociatedDataEnum.other(unnamed, m_1);
-    }
+    AssociatedDataEnum shallowCopy() => AssociatedDataEnum.other(unnamed, m_1);
 }
 
 class AssociatedDataEnum_Bar extends AssociatedDataEnum {
@@ -349,9 +343,7 @@ class AssociatedDataEnum_Bar extends AssociatedDataEnum {
     }
 
     @override
-    AssociatedDataEnum shallowCopy() {
-        return AssociatedDataEnum.bar(named, m_1);
-    }
+    AssociatedDataEnum shallowCopy() => AssociatedDataEnum.bar(named, m_1);
 }
 
 class AssociatedDataEnum_NoValue extends AssociatedDataEnum {
@@ -375,9 +367,7 @@ class AssociatedDataEnum_NoValue extends AssociatedDataEnum {
     }
 
     @override
-    AssociatedDataEnum shallowCopy() {
-        return AssociatedDataEnum.noValue();
-    }
+    AssociatedDataEnum shallowCopy() => AssociatedDataEnum.noValue();
 }
 
 class AssociatedDataEnum_SimpleEnum extends AssociatedDataEnum {
@@ -409,7 +399,5 @@ class AssociatedDataEnum_SimpleEnum extends AssociatedDataEnum {
     }
 
     @override
-    AssociatedDataEnum shallowCopy() {
-        return AssociatedDataEnum.simpleEnum(value);
-    }
+    AssociatedDataEnum shallowCopy() => AssociatedDataEnum.simpleEnum(value);
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/AssociatedDataEnum.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/AssociatedDataEnum.dart
@@ -266,9 +266,7 @@ class AssociatedDataEnum_Thing extends AssociatedDataEnum {
     );
 
     @override
-    String toString() {
-        return 'AssociatedDataEnum.thing(value: $value)';
-    }
+    String toString() => 'AssociatedDataEnum.thing(value: $value)';
 
     @override
     AssociatedDataEnum shallowCopy() => AssociatedDataEnum.thing(value);
@@ -302,9 +300,7 @@ class AssociatedDataEnum_Other extends AssociatedDataEnum {
     );
 
     @override
-    String toString() {
-        return 'AssociatedDataEnum.other(unnamed: $unnamed, m_1: $m_1)';
-    }
+    String toString() => 'AssociatedDataEnum.other(unnamed: $unnamed, m_1: $m_1)';
 
     @override
     AssociatedDataEnum shallowCopy() => AssociatedDataEnum.other(unnamed, m_1);
@@ -338,9 +334,7 @@ class AssociatedDataEnum_Bar extends AssociatedDataEnum {
     );
 
     @override
-    String toString() {
-        return 'AssociatedDataEnum.bar(named: $named, m_1: $m_1)';
-    }
+    String toString() => 'AssociatedDataEnum.bar(named: $named, m_1: $m_1)';
 
     @override
     AssociatedDataEnum shallowCopy() => AssociatedDataEnum.bar(named, m_1);
@@ -362,9 +356,7 @@ class AssociatedDataEnum_NoValue extends AssociatedDataEnum {
     int get hashCode => runtimeType.hashCode;
 
     @override
-    String toString() {
-        return 'AssociatedDataEnum.noValue()';
-    }
+    String toString() => 'AssociatedDataEnum.noValue()';
 
     @override
     AssociatedDataEnum shallowCopy() => AssociatedDataEnum.noValue();
@@ -394,9 +386,7 @@ class AssociatedDataEnum_SimpleEnum extends AssociatedDataEnum {
     );
 
     @override
-    String toString() {
-        return 'AssociatedDataEnum.simpleEnum(value: $value)';
-    }
+    String toString() => 'AssociatedDataEnum.simpleEnum(value: $value)';
 
     @override
     AssociatedDataEnum shallowCopy() => AssociatedDataEnum.simpleEnum(value);

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/AssociatedDataEnum.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/AssociatedDataEnum.dart
@@ -238,6 +238,10 @@ sealed class AssociatedDataEnum {
         Env env,
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_AssociatedDataEnum_staticThing;
+
+    AssociatedDataEnum shallowCopy() {
+        throw UnsupportedError('AssociatedDataEnum shallowCopy() must be overridden by a subclass.');
+    }
 }
 
 class AssociatedDataEnum_Thing extends AssociatedDataEnum {
@@ -266,6 +270,11 @@ class AssociatedDataEnum_Thing extends AssociatedDataEnum {
     @override
     String toString() {
         return 'AssociatedDataEnum.thing(value: $value)';
+    }
+
+    @override
+    AssociatedDataEnum shallowCopy() {
+        return AssociatedDataEnum.thing(value);
     }
 }
 
@@ -300,6 +309,11 @@ class AssociatedDataEnum_Other extends AssociatedDataEnum {
     String toString() {
         return 'AssociatedDataEnum.other(unnamed: $unnamed, m_1: $m_1)';
     }
+
+    @override
+    AssociatedDataEnum shallowCopy() {
+        return AssociatedDataEnum.other(unnamed, m_1);
+    }
 }
 
 class AssociatedDataEnum_Bar extends AssociatedDataEnum {
@@ -333,6 +347,11 @@ class AssociatedDataEnum_Bar extends AssociatedDataEnum {
     String toString() {
         return 'AssociatedDataEnum.bar(named: $named, m_1: $m_1)';
     }
+
+    @override
+    AssociatedDataEnum shallowCopy() {
+        return AssociatedDataEnum.bar(named, m_1);
+    }
 }
 
 class AssociatedDataEnum_NoValue extends AssociatedDataEnum {
@@ -353,6 +372,11 @@ class AssociatedDataEnum_NoValue extends AssociatedDataEnum {
     @override
     String toString() {
         return 'AssociatedDataEnum.noValue()';
+    }
+
+    @override
+    AssociatedDataEnum shallowCopy() {
+        return AssociatedDataEnum.noValue();
     }
 }
 
@@ -382,5 +406,10 @@ class AssociatedDataEnum_SimpleEnum extends AssociatedDataEnum {
     @override
     String toString() {
         return 'AssociatedDataEnum.simpleEnum(value: $value)';
+    }
+
+    @override
+    AssociatedDataEnum shallowCopy() {
+        return AssociatedDataEnum.simpleEnum(value);
     }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/AttributedStrings.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/AttributedStrings.dart
@@ -255,4 +255,8 @@ class AttributedStrings {
         Env env,
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_AttributedStrings_simple;
+
+    AttributedStrings shallowCopy() {
+        throw UnsupportedError('AttributedStrings shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/AttributedStrings.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/AttributedStrings.dart
@@ -256,7 +256,5 @@ class AttributedStrings {
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_AttributedStrings_simple;
 
-    AttributedStrings shallowCopy() {
-        throw UnsupportedError('AttributedStrings shallowCopy() must be overridden by a subclass.');
-    }
+    AttributedStrings shallowCopy() => throw UnsupportedError('AttributedStrings shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Bytes.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Bytes.dart
@@ -116,7 +116,5 @@ class Bytes {
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Bytes_data;
 
-    Bytes shallowCopy() {
-        throw UnsupportedError('Bytes shallowCopy() must be overridden by a subclass.');
-    }
+    Bytes shallowCopy() => throw UnsupportedError('Bytes shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Bytes.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Bytes.dart
@@ -115,4 +115,8 @@ class Bytes {
         Env env,
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Bytes_data;
+
+    Bytes shallowCopy() {
+        throw UnsupportedError('Bytes shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ClosedRanges.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ClosedRanges.dart
@@ -380,7 +380,5 @@ class ClosedRanges {
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_ClosedRanges_uIntRange;
 
-    ClosedRanges shallowCopy() {
-        throw UnsupportedError('ClosedRanges shallowCopy() must be overridden by a subclass.');
-    }
+    ClosedRanges shallowCopy() => throw UnsupportedError('ClosedRanges shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ClosedRanges.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ClosedRanges.dart
@@ -379,4 +379,8 @@ class ClosedRanges {
         Env env,
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_ClosedRanges_uIntRange;
+
+    ClosedRanges shallowCopy() {
+        throw UnsupportedError('ClosedRanges shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Collections.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Collections.dart
@@ -279,4 +279,8 @@ class Collections {
         Env env,
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Collections_setOfInt;
+
+    Collections shallowCopy() {
+        throw UnsupportedError('Collections shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Collections.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Collections.dart
@@ -280,7 +280,5 @@ class Collections {
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Collections_setOfInt;
 
-    Collections shallowCopy() {
-        throw UnsupportedError('Collections shallowCopy() must be overridden by a subclass.');
-    }
+    Collections shallowCopy() => throw UnsupportedError('Collections shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/DefaultArguments.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/DefaultArguments.dart
@@ -89,4 +89,8 @@ class DefaultArguments {
         double z,
         OutCreatedRef _exn
     ) f__iota_TestAPI_DefaultArguments_echoDefaults;
+
+    DefaultArguments shallowCopy() {
+        throw UnsupportedError('DefaultArguments shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/DefaultArguments.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/DefaultArguments.dart
@@ -90,7 +90,5 @@ class DefaultArguments {
         OutCreatedRef _exn
     ) f__iota_TestAPI_DefaultArguments_echoDefaults;
 
-    DefaultArguments shallowCopy() {
-        throw UnsupportedError('DefaultArguments shallowCopy() must be overridden by a subclass.');
-    }
+    DefaultArguments shallowCopy() => throw UnsupportedError('DefaultArguments shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Deprecations.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Deprecations.dart
@@ -89,4 +89,8 @@ class Deprecations {
         Env env,
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Deprecations_deprecatedVariable;
+
+    Deprecations shallowCopy() {
+        throw UnsupportedError('Deprecations shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Deprecations.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Deprecations.dart
@@ -90,7 +90,5 @@ class Deprecations {
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Deprecations_deprecatedVariable;
 
-    Deprecations shallowCopy() {
-        throw UnsupportedError('Deprecations shallowCopy() must be overridden by a subclass.');
-    }
+    Deprecations shallowCopy() => throw UnsupportedError('Deprecations shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyEnum.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyEnum.dart
@@ -78,7 +78,5 @@ class EmptyEnum {
         OutCreatedRef _exn
     ) f__iota_TestAPI_EmptyEnum_notGoingToHappen;
 
-    EmptyEnum shallowCopy() {
-        throw UnsupportedError('EmptyEnum shallowCopy() must be overridden by a subclass.');
-    }
+    EmptyEnum shallowCopy() => throw UnsupportedError('EmptyEnum shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyEnum.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyEnum.dart
@@ -77,4 +77,8 @@ class EmptyEnum {
         Env env,
         OutCreatedRef _exn
     ) f__iota_TestAPI_EmptyEnum_notGoingToHappen;
+
+    EmptyEnum shallowCopy() {
+        throw UnsupportedError('EmptyEnum shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Functions.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Functions.dart
@@ -245,4 +245,8 @@ class Functions {
         Env env,
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Functions_sixthThing;
+
+    Functions shallowCopy() {
+        throw UnsupportedError('Functions shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Functions.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Functions.dart
@@ -246,7 +246,5 @@ class Functions {
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Functions_sixthThing;
 
-    Functions shallowCopy() {
-        throw UnsupportedError('Functions shallowCopy() must be overridden by a subclass.');
-    }
+    Functions shallowCopy() => throw UnsupportedError('Functions shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Primitives.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Primitives.dart
@@ -1094,7 +1094,5 @@ class Primitives {
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Primitives_zeroUInt8;
 
-    Primitives shallowCopy() {
-        throw UnsupportedError('Primitives shallowCopy() must be overridden by a subclass.');
-    }
+    Primitives shallowCopy() => throw UnsupportedError('Primitives shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Primitives.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Primitives.dart
@@ -1093,4 +1093,8 @@ class Primitives {
         Env env,
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Primitives_zeroUInt8;
+
+    Primitives shallowCopy() {
+        throw UnsupportedError('Primitives shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Ranges.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Ranges.dart
@@ -307,4 +307,8 @@ class Ranges {
         Env env,
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Ranges_uIntRange;
+
+    Ranges shallowCopy() {
+        throw UnsupportedError('Ranges shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Ranges.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Ranges.dart
@@ -308,7 +308,5 @@ class Ranges {
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Ranges_uIntRange;
 
-    Ranges shallowCopy() {
-        throw UnsupportedError('Ranges shallowCopy() must be overridden by a subclass.');
-    }
+    Ranges shallowCopy() => throw UnsupportedError('Ranges shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/SimpleEnum.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/SimpleEnum.dart
@@ -219,9 +219,7 @@ class SimpleEnum_Red extends SimpleEnum {
     int get hashCode => runtimeType.hashCode;
 
     @override
-    String toString() {
-        return 'SimpleEnum.red()';
-    }
+    String toString() => 'SimpleEnum.red()';
 
     @override
     SimpleEnum shallowCopy() => SimpleEnum.red();
@@ -243,9 +241,7 @@ class SimpleEnum_Green extends SimpleEnum {
     int get hashCode => runtimeType.hashCode;
 
     @override
-    String toString() {
-        return 'SimpleEnum.green()';
-    }
+    String toString() => 'SimpleEnum.green()';
 
     @override
     SimpleEnum shallowCopy() => SimpleEnum.green();
@@ -267,9 +263,7 @@ class SimpleEnum_Blue extends SimpleEnum {
     int get hashCode => runtimeType.hashCode;
 
     @override
-    String toString() {
-        return 'SimpleEnum.blue()';
-    }
+    String toString() => 'SimpleEnum.blue()';
 
     @override
     SimpleEnum shallowCopy() => SimpleEnum.blue();

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/SimpleEnum.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/SimpleEnum.dart
@@ -199,6 +199,10 @@ sealed class SimpleEnum {
         UnownedRef favoriteColor,
         OutCreatedRef _exn
     ) f__iota_set_TestAPI_SimpleEnum_favoriteColor;
+
+    SimpleEnum shallowCopy() {
+        throw UnsupportedError('SimpleEnum shallowCopy() must be overridden by a subclass.');
+    }
 }
 
 class SimpleEnum_Red extends SimpleEnum {
@@ -219,6 +223,11 @@ class SimpleEnum_Red extends SimpleEnum {
     @override
     String toString() {
         return 'SimpleEnum.red()';
+    }
+
+    @override
+    SimpleEnum shallowCopy() {
+        return SimpleEnum.red();
     }
 }
 
@@ -241,6 +250,11 @@ class SimpleEnum_Green extends SimpleEnum {
     String toString() {
         return 'SimpleEnum.green()';
     }
+
+    @override
+    SimpleEnum shallowCopy() {
+        return SimpleEnum.green();
+    }
 }
 
 class SimpleEnum_Blue extends SimpleEnum {
@@ -261,5 +275,10 @@ class SimpleEnum_Blue extends SimpleEnum {
     @override
     String toString() {
         return 'SimpleEnum.blue()';
+    }
+
+    @override
+    SimpleEnum shallowCopy() {
+        return SimpleEnum.blue();
     }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/SimpleEnum.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/SimpleEnum.dart
@@ -200,9 +200,7 @@ sealed class SimpleEnum {
         OutCreatedRef _exn
     ) f__iota_set_TestAPI_SimpleEnum_favoriteColor;
 
-    SimpleEnum shallowCopy() {
-        throw UnsupportedError('SimpleEnum shallowCopy() must be overridden by a subclass.');
-    }
+    SimpleEnum shallowCopy() => throw UnsupportedError('SimpleEnum shallowCopy() must be overridden by a subclass.');
 }
 
 class SimpleEnum_Red extends SimpleEnum {
@@ -226,9 +224,7 @@ class SimpleEnum_Red extends SimpleEnum {
     }
 
     @override
-    SimpleEnum shallowCopy() {
-        return SimpleEnum.red();
-    }
+    SimpleEnum shallowCopy() => SimpleEnum.red();
 }
 
 class SimpleEnum_Green extends SimpleEnum {
@@ -252,9 +248,7 @@ class SimpleEnum_Green extends SimpleEnum {
     }
 
     @override
-    SimpleEnum shallowCopy() {
-        return SimpleEnum.green();
-    }
+    SimpleEnum shallowCopy() => SimpleEnum.green();
 }
 
 class SimpleEnum_Blue extends SimpleEnum {
@@ -278,7 +272,5 @@ class SimpleEnum_Blue extends SimpleEnum {
     }
 
     @override
-    SimpleEnum shallowCopy() {
-        return SimpleEnum.blue();
-    }
+    SimpleEnum shallowCopy() => SimpleEnum.blue();
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/SimpleEnum.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/SimpleEnum.dart
@@ -215,6 +215,11 @@ class SimpleEnum_Red extends SimpleEnum {
 
     @override
     int get hashCode => runtimeType.hashCode;
+
+    @override
+    String toString() {
+        return 'SimpleEnum.red()';
+    }
 }
 
 class SimpleEnum_Green extends SimpleEnum {
@@ -231,6 +236,11 @@ class SimpleEnum_Green extends SimpleEnum {
 
     @override
     int get hashCode => runtimeType.hashCode;
+
+    @override
+    String toString() {
+        return 'SimpleEnum.green()';
+    }
 }
 
 class SimpleEnum_Blue extends SimpleEnum {
@@ -247,4 +257,9 @@ class SimpleEnum_Blue extends SimpleEnum {
 
     @override
     int get hashCode => runtimeType.hashCode;
+
+    @override
+    String toString() {
+        return 'SimpleEnum.blue()';
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Strings.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Strings.dart
@@ -162,7 +162,5 @@ class Strings {
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Strings_simple;
 
-    Strings shallowCopy() {
-        throw UnsupportedError('Strings shallowCopy() must be overridden by a subclass.');
-    }
+    Strings shallowCopy() => throw UnsupportedError('Strings shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Strings.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Strings.dart
@@ -161,4 +161,8 @@ class Strings {
         Env env,
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Strings_simple;
+
+    Strings shallowCopy() {
+        throw UnsupportedError('Strings shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs.dart
@@ -66,4 +66,8 @@ class Structs {
     static int enumDiscriminator(UnownedRef obj, OutCreatedRef exn) => check((exn) {
         throw UnsupportedError('This class is supposed to be uninhabited');
     });
+
+    Structs shallowCopy() {
+        throw UnsupportedError('Structs shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs.dart
@@ -67,7 +67,5 @@ class Structs {
         throw UnsupportedError('This class is supposed to be uninhabited');
     });
 
-    Structs shallowCopy() {
-        throw UnsupportedError('Structs shallowCopy() must be overridden by a subclass.');
-    }
+    Structs shallowCopy() => throw UnsupportedError('Structs shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Tuples.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Tuples.dart
@@ -148,7 +148,5 @@ class Tuples {
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Tuples_tuple6;
 
-    Tuples shallowCopy() {
-        throw UnsupportedError('Tuples shallowCopy() must be overridden by a subclass.');
-    }
+    Tuples shallowCopy() => throw UnsupportedError('Tuples shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Tuples.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Tuples.dart
@@ -147,4 +147,8 @@ class Tuples {
         Env env,
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_Tuples_tuple6;
+
+    Tuples shallowCopy() {
+        throw UnsupportedError('Tuples shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/URLs.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/URLs.dart
@@ -112,7 +112,5 @@ class URLs {
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_URLs_simple;
 
-    URLs shallowCopy() {
-        throw UnsupportedError('URLs shallowCopy() must be overridden by a subclass.');
-    }
+    URLs shallowCopy() => throw UnsupportedError('URLs shallowCopy() must be overridden by a subclass.');
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/URLs.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/URLs.dart
@@ -111,4 +111,8 @@ class URLs {
         Env env,
         OutCreatedRef _exn
     ) f__iota_get_TestAPI_URLs_simple;
+
+    URLs shallowCopy() {
+        throw UnsupportedError('URLs shallowCopy() must be overridden by a subclass.');
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/UnicodeScalar_PuttingTypesIntoQuestionablePlaces.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/UnicodeScalar_PuttingTypesIntoQuestionablePlaces.dart
@@ -102,9 +102,7 @@ sealed class UnicodeScalar_PuttingTypesIntoQuestionablePlaces {
         OutCreatedRef _exn
     ) f__iota_Swift_UnicodeScalar_PuttingTypesIntoQuestionablePlaces_testCall;
 
-    UnicodeScalar_PuttingTypesIntoQuestionablePlaces shallowCopy() {
-        throw UnsupportedError('UnicodeScalar_PuttingTypesIntoQuestionablePlaces shallowCopy() must be overridden by a subclass.');
-    }
+    UnicodeScalar_PuttingTypesIntoQuestionablePlaces shallowCopy() => throw UnsupportedError('UnicodeScalar_PuttingTypesIntoQuestionablePlaces shallowCopy() must be overridden by a subclass.');
 }
 
 class UnicodeScalar_PuttingTypesIntoQuestionablePlaces_Thing extends UnicodeScalar_PuttingTypesIntoQuestionablePlaces {
@@ -128,7 +126,5 @@ class UnicodeScalar_PuttingTypesIntoQuestionablePlaces_Thing extends UnicodeScal
     }
 
     @override
-    UnicodeScalar_PuttingTypesIntoQuestionablePlaces shallowCopy() {
-        return UnicodeScalar_PuttingTypesIntoQuestionablePlaces.thing();
-    }
+    UnicodeScalar_PuttingTypesIntoQuestionablePlaces shallowCopy() => UnicodeScalar_PuttingTypesIntoQuestionablePlaces.thing();
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/UnicodeScalar_PuttingTypesIntoQuestionablePlaces.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/UnicodeScalar_PuttingTypesIntoQuestionablePlaces.dart
@@ -101,6 +101,10 @@ sealed class UnicodeScalar_PuttingTypesIntoQuestionablePlaces {
         UnownedRef _this,
         OutCreatedRef _exn
     ) f__iota_Swift_UnicodeScalar_PuttingTypesIntoQuestionablePlaces_testCall;
+
+    UnicodeScalar_PuttingTypesIntoQuestionablePlaces shallowCopy() {
+        throw UnsupportedError('UnicodeScalar_PuttingTypesIntoQuestionablePlaces shallowCopy() must be overridden by a subclass.');
+    }
 }
 
 class UnicodeScalar_PuttingTypesIntoQuestionablePlaces_Thing extends UnicodeScalar_PuttingTypesIntoQuestionablePlaces {
@@ -121,5 +125,10 @@ class UnicodeScalar_PuttingTypesIntoQuestionablePlaces_Thing extends UnicodeScal
     @override
     String toString() {
         return 'UnicodeScalar_PuttingTypesIntoQuestionablePlaces.thing()';
+    }
+
+    @override
+    UnicodeScalar_PuttingTypesIntoQuestionablePlaces shallowCopy() {
+        return UnicodeScalar_PuttingTypesIntoQuestionablePlaces.thing();
     }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/UnicodeScalar_PuttingTypesIntoQuestionablePlaces.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/UnicodeScalar_PuttingTypesIntoQuestionablePlaces.dart
@@ -121,9 +121,7 @@ class UnicodeScalar_PuttingTypesIntoQuestionablePlaces_Thing extends UnicodeScal
     int get hashCode => runtimeType.hashCode;
 
     @override
-    String toString() {
-        return 'UnicodeScalar_PuttingTypesIntoQuestionablePlaces.thing()';
-    }
+    String toString() => 'UnicodeScalar_PuttingTypesIntoQuestionablePlaces.thing()';
 
     @override
     UnicodeScalar_PuttingTypesIntoQuestionablePlaces shallowCopy() => UnicodeScalar_PuttingTypesIntoQuestionablePlaces.thing();

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/UnicodeScalar_PuttingTypesIntoQuestionablePlaces.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/UnicodeScalar_PuttingTypesIntoQuestionablePlaces.dart
@@ -117,4 +117,9 @@ class UnicodeScalar_PuttingTypesIntoQuestionablePlaces_Thing extends UnicodeScal
 
     @override
     int get hashCode => runtimeType.hashCode;
+
+    @override
+    String toString() {
+        return 'UnicodeScalar_PuttingTypesIntoQuestionablePlaces.thing()';
+    }
 }

--- a/integration-tests/TestAPI-bindings/dart/test/enum_test.dart
+++ b/integration-tests/TestAPI-bindings/dart/test/enum_test.dart
@@ -1,3 +1,5 @@
+import 'dart:js_util';
+
 import 'package:cricut_test_api/cricut_test_api.dart';
 import 'package:test/test.dart';
 
@@ -61,6 +63,21 @@ void main() {
           expect(shape2("hello", "world", 8).intValue, equals(11));
           expect(shape1(2).plus(shape2("x", "y", 4)), equals(shape1(9)));
           expect(shape2("y", "z", 2).plus(shape1(5)), equals(shape2("y", "z", 7)));
+      });
+
+      test('testEnumToString', () {
+        var r = SimpleEnum.red();
+        var g = SimpleEnum.green();
+        var b = SimpleEnum.blue();
+
+        expect(r.toString(), equals("SimpleEnum.red()"));
+        expect(g.toString(), equals("SimpleEnum.green()"));
+        expect(b.toString(), equals("SimpleEnum.blue()"));
+
+        var x = AssociatedDataEnum.thing(90);
+        expect(x.toString(), equals("AssociatedDataEnum.thing(value: 90)"));
+        var y = AssociatedDataEnum.bar("qux", x);
+        expect(y.toString(), equals("AssociatedDataEnum.bar(named: qux, m_1: AssociatedDataEnum.thing(value: 90))"));
       });
   });
 }

--- a/integration-tests/TestAPI-bindings/dart/test/enum_test.dart
+++ b/integration-tests/TestAPI-bindings/dart/test/enum_test.dart
@@ -80,6 +80,15 @@ void main() {
         expect(y.toString(), equals("AssociatedDataEnum.bar(named: qux, m_1: AssociatedDataEnum.thing(value: 90))"));
       });
 
+      test('testEnumToString', () {
+        var a = SimpleEnum.blue();
+        expect(a.toString(), equals("SimpleEnum.blue()"));
+
+        var b = AssociatedDataEnum.simpleEnum(a);
+        var c = AssociatedDataEnum.bar("qux", b);
+        expect(c.toString(), equals("AssociatedDataEnum.bar(named: qux, m_1: AssociatedDataEnum.simpleEnum(value: SimpleEnum.blue()))"));
+      });
+
       test('testEnumShallowCopy', () {
           var a = SimpleEnum.blue();
           var b = a.shallowCopy();

--- a/integration-tests/TestAPI-bindings/dart/test/enum_test.dart
+++ b/integration-tests/TestAPI-bindings/dart/test/enum_test.dart
@@ -102,5 +102,23 @@ void main() {
           var k = AssociatedDataEnum.thing(124);
           expect(k != h, true);
       });
+
+      test('testHashCode', () {
+        var a = SimpleEnum.green();
+        var b = SimpleEnum.green();
+        var c = SimpleEnum.red();
+
+        expect(a.hashCode, equals(b.hashCode));
+        expect(c.hashCode != b.hashCode, true);
+
+        var d = AssociatedDataEnum.simpleEnum(a);
+        var e = AssociatedDataEnum.simpleEnum(b);
+        var f = AssociatedDataEnum.simpleEnum(c);
+        var g = AssociatedDataEnum.bar("garply", d);
+        var h = AssociatedDataEnum.bar("garply", e);
+        var i = AssociatedDataEnum.bar("garply", f);
+        expect(g.hashCode, equals(h.hashCode));
+        expect(i.hashCode != h.hashCode, true);
+      });
   });
 }

--- a/integration-tests/TestAPI-bindings/dart/test/enum_test.dart
+++ b/integration-tests/TestAPI-bindings/dart/test/enum_test.dart
@@ -79,5 +79,28 @@ void main() {
         var y = AssociatedDataEnum.bar("qux", x);
         expect(y.toString(), equals("AssociatedDataEnum.bar(named: qux, m_1: AssociatedDataEnum.thing(value: 90))"));
       });
+
+      test('testEnumShallowCopy', () {
+          var a = SimpleEnum.blue();
+          var b = a.shallowCopy();
+          var c = SimpleEnum.green();
+          var d = c.shallowCopy();
+          expect(a == b, true);
+          expect(c, equals(d));
+          expect(b != d, true);
+
+          var e = AssociatedDataEnum.simpleEnum(b);
+          var f = AssociatedDataEnum.bar("corge", e);
+          var g = f.shallowCopy();
+          expect(g, equals(f));
+
+          var h = AssociatedDataEnum.thing(123);
+          var i = h.shallowCopy();
+          var j = i.shallowCopy();
+          expect(i, equals(h));
+          expect(j, equals(h));
+          var k = AssociatedDataEnum.thing(124);
+          expect(k != h, true);
+      });
   });
 }

--- a/integration-tests/TestAPI-bindings/dart/test/enum_test.dart
+++ b/integration-tests/TestAPI-bindings/dart/test/enum_test.dart
@@ -1,5 +1,3 @@
-import 'dart:js_util';
-
 import 'package:cricut_test_api/cricut_test_api.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
AB#426027 Put in toString, shallowCopy, and test for hashCode on dart sealed class enums

Dart doesn't support any kind of built in deepCopy so I went with a shallowCopy: https://stackoverflow.com/questions/13107906/how-can-i-clone-an-object-deep-copy-in-dart/67420251#67420251