### PR TITLE
Fix for when no requiredParams but still have optionalParams

### DIFF
--- a/Sources/FishyJoesCore/Unparse/DartClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartClass.swift
@@ -458,6 +458,9 @@ extension DartClass {
             guard !method.documentation.isEmpty else {
                 continue
             }
+            guard !method.isStatic else {
+                continue
+            }
             fragment.outputBlock("static \(method.returnType.ffiCreatedName) ffi_\(method.name)(", newLineTerminated: false) {
                 fragment.output("UnownedRef obj,")
                 for param in method.parameters {

--- a/Sources/FishyJoesCore/Unparse/DartClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartClass.swift
@@ -503,7 +503,9 @@ extension DartClass {
                         }
                     }
                     if !optionalParams.isEmpty {
-                        fragment.output(",")
+                        if !requiredParams.isEmpty {
+                            fragment.output(",")
+                        }
                         fragment.outputMap(optionalParams, separator: ",") {
                             if $0.type.isObject {
                                 return "\($0.name): consumeRef(\($0.name))"

--- a/Sources/FishyJoesCore/Unparse/DartClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartClass.swift
@@ -510,7 +510,7 @@ extension DartClass {
                             if $0.type.isObject {
                                 return "\($0.name): consumeRef(\($0.name))"
                             } else {
-                                return $0.name
+                                return "\($0.name): \($0.name)"
                             }
                         }
                     } else {

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Actors_TemperatureLogger.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Actors_TemperatureLogger.dart
@@ -83,20 +83,6 @@ class Actors_TemperatureLogger extends SwiftReference {
         )
     );
 
-    static CreatedRef ffi_create(
-        UnownedRef obj,
-        ConsumedRef label,
-        int measurement,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Actors_TemperatureLogger.create(
-                consumeRef(label),
-                measurement
-            )
-        )
-    );
-
     static CreatedRef ffi_update(
         UnownedRef obj,
         int measurement,

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Methods.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Methods.dart
@@ -128,16 +128,6 @@ class Methods extends SwiftReference {
         peekRef<Methods>(obj).instanceStored
     ) ?? 0;
 
-    static CreatedRef ffi_create(
-        UnownedRef obj,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Methods.create(
-            )
-        )
-    );
-
     static int ffi_doublePlusGood(
         UnownedRef obj,
         int a,
@@ -233,94 +223,6 @@ class Methods extends SwiftReference {
     ) => catchingRef(exn, () =>
         createRef(
             peekRef<Methods>(obj).asyncCallbackFunc0(
-                consumeRef(callback)
-            )
-        )
-    );
-
-    static CreatedRef ffi_staticAsync42(
-        UnownedRef obj,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Methods.staticAsync42(
-            )
-        )
-    );
-
-    static CreatedRef ffi_staticAsyncYield(
-        UnownedRef obj,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Methods.staticAsyncYield(
-            )
-        )
-    );
-
-    static CreatedRef ffi_staticAsyncSleep(
-        UnownedRef obj,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Methods.staticAsyncSleep(
-            )
-        )
-    );
-
-    static CreatedRef ffi_staticAsyncVoid(
-        UnownedRef obj,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Methods.staticAsyncVoid(
-            )
-        )
-    );
-
-    static CreatedRef ffi_staticAsyncDouble(
-        UnownedRef obj,
-        double d,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Methods.staticAsyncDouble(
-                d
-            )
-        )
-    );
-
-    static CreatedRef ffi_staticAsyncMultipleArgs(
-        UnownedRef obj,
-        int i,
-        ConsumedRef j,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Methods.staticAsyncMultipleArgs(
-                i,
-                consumeRef(j)
-            )
-        )
-    );
-
-    static CreatedRef ffi_staticAsyncThrowing(
-        UnownedRef obj,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Methods.staticAsyncThrowing(
-            )
-        )
-    );
-
-    static CreatedRef ffi_staticAsyncCallbackFunc0(
-        UnownedRef obj,
-        ConsumedRef callback,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Methods.staticAsyncCallbackFunc0(
                 consumeRef(callback)
             )
         )

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_MemberwiseStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_MemberwiseStruct.dart
@@ -123,16 +123,6 @@ class Structs_MemberwiseStruct {
         )
     );
 
-    static CreatedRef ffi_create(
-        UnownedRef obj,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Structs_MemberwiseStruct.create(
-            )
-        )
-    );
-
     @override
     bool operator ==(Object other) {
         return identical(other, this) ||

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_MutableStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_MutableStruct.dart
@@ -117,16 +117,6 @@ class Structs_MutableStruct {
         )
     );
 
-    static CreatedRef ffi_create(
-        UnownedRef obj,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Structs_MutableStruct.create(
-            )
-        )
-    );
-
     @override
     bool operator ==(Object other) {
         return identical(other, this) ||

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_PuttingTypesIntoQuestionablePlaces.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_PuttingTypesIntoQuestionablePlaces.dart
@@ -65,16 +65,6 @@ class Structs_PuttingTypesIntoQuestionablePlaces extends SwiftReference {
     @override
     String toString() => 'Structs_PuttingTypesIntoQuestionablePlaces()';
 
-    static CreatedRef ffi_create(
-        UnownedRef obj,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Structs_PuttingTypesIntoQuestionablePlaces.create(
-            )
-        )
-    );
-
     static int ffi_testCall(
         UnownedRef obj,
         OutCreatedRef exn

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_ReferenceStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_ReferenceStruct.dart
@@ -90,16 +90,6 @@ class Structs_ReferenceStruct extends SwiftReference {
         peekRef<Structs_ReferenceStruct>(obj).hashCode
     ) ?? 0;
 
-    static CreatedRef ffi_create(
-        UnownedRef obj,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            Structs_ReferenceStruct.create(
-            )
-        )
-    );
-
     static CreatedRef ffi_asyncGetMutable(
         UnownedRef obj,
         OutCreatedRef exn

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestProtocolClass.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestProtocolClass.dart
@@ -156,20 +156,6 @@ class TestProtocolClass extends SwiftReference implements TestAPI.TestMethodsPro
         )
     );
 
-    static CreatedRef ffi_init(
-        UnownedRef obj,
-        ConsumedRef corge,
-        ConsumedRef flarp,
-        OutCreatedRef exn
-    ) => catchingRef(exn, () =>
-        createRef(
-            TestProtocolClass.init(
-                consumeRef(corge),
-                flarp: consumeRef(flarp)
-            )
-        )
-    );
-
     static CreatedRef ffi_wombat(
         UnownedRef obj,
         ConsumedRef zxc,


### PR DESCRIPTION
also

don't do ffi for static methods

Use name: name for optional parameters since I made them named in the function signature.