### PR TITLE
Add missing CMakeLists for linux fishyjoes_dart

### DIFF
--- a/Sources/FishyJoesExecute/Resources/bindings-template/dart/linux/CMakeLists.txt
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/dart/linux/CMakeLists.txt
@@ -14,6 +14,5 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 set(cricut___LOWERCASE_MODULE_NAME___bundled_libraries
   ${CMAKE_CURRENT_SOURCE_DIR}/native/lib__MODULE_NAME__.so
   ${CMAKE_CURRENT_SOURCE_DIR}/native/lib__MODULE_NAME__-iota.so
-  ${CMAKE_CURRENT_SOURCE_DIR}/native/libFishyJoesIotaRuntime.so
   PARENT_SCOPE
 )

--- a/dart-runtime/linux/CMakeLists.txt
+++ b/dart-runtime/linux/CMakeLists.txt
@@ -5,14 +5,13 @@
 cmake_minimum_required(VERSION 3.14)
 
 # Project-level configuration.
-set(PROJECT_NAME "__LOWERCASE_MODULE_NAME___flutter")
-project(${PROJECT_NAME} LANGUAGES CXX)
+set(PROJECT_NAME "fishyjoes_runtime")
+project(${PROJECT_NAME})
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 # This list could contain prebuilt libraries, or libraries created by an
 # external build triggered from this build file.
-set(cricut___LOWERCASE_MODULE_NAME___bundled_libraries
-  ${CMAKE_CURRENT_SOURCE_DIR}/native/__MODULE_NAME__.dll
-  ${CMAKE_CURRENT_SOURCE_DIR}/native/__MODULE_NAME__-iota.dll
+set(fishyjoes_dart_bundled_libraries
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/libFishyJoesIotaRuntime.so
   PARENT_SCOPE
 )


### PR DESCRIPTION
- Add missing CMakeLists for linux fishyjoes_dart package
- Modify templates to remove adding libFishyJoesIotaRuntime which will not be there in each individual bindings npm package. libFishyJoesIotaRuntime will be added once as a part of fishyjoes_dart package