### PR TITLE
Bundling swift runtime with dart-runtime for Windows

### DIFF
--- a/dart-runtime/windows/CMakeLists.txt
+++ b/dart-runtime/windows/CMakeLists.txt
@@ -16,5 +16,21 @@ set(FISHYJOES_SHARED_LIB_PATH "${CMAKE_CURRENT_SOURCE_DIR}/native/${FISHYJOES_SH
 # external build triggered from this build file.
 set(fishyjoes_runtime_bundled_libraries
   ${FISHYJOES_SHARED_LIB_PATH}
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/BlocksRuntime.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/dispatch.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/Foundation.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/FoundationNetworking.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/FoundationXML.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/swift_Concurrency.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/swift_Differentiation.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/swift_RegexParser.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/swift_StringProcessing.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/swiftCore.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/swiftCRT.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/swiftDispatch.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/swiftDistributed.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/swiftRemoteMirror.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/swiftSwiftOnoneSupport.dll
+  ${CMAKE_CURRENT_SOURCE_DIR}/native/swiftWinSDK.dll
   PARENT_SCOPE
 )


### PR DESCRIPTION
For a Heimdall installation to work properly on Windows, we need Flutter to bundle the Swift runtime.