### PR TITLE
Dvoss/create double doubley

### DIFF
--- a/Sources/FishyJoesCore/Translators/NodeTranslator.swift
+++ b/Sources/FishyJoesCore/Translators/NodeTranslator.swift
@@ -289,6 +289,8 @@ struct NodeTranslator: Translator {
                 let resolved = context.resolve(type: type)
                 nodeTypeListFragment.output("try \(resolved.converterType.name).nodeSetup(env: env, module: module)")
             }
+            nodeTypeListFragment.output("// call once in TypeSetup to \"prime the pump\" so to speak aka work around a bug that may be related to win_delay_hook stuff put in by Stoker.")
+            nodeTypeListFragment.output("_ = try env.createDouble(42.0)")
             nodeTypeListFragment.output("return exports")
         }
         nodeTypeListFragment.blankLine()

--- a/Sources/FishyJoesNodeRuntime/NAPI.swift
+++ b/Sources/FishyJoesNodeRuntime/NAPI.swift
@@ -268,7 +268,9 @@ extension NAPI.Env {
         return result
     }
     public func createDouble(_ value: Double) throws -> NAPI.Value {
+        var resultCouldBeBadOnWindows = NAPI.Value()
         var result = NAPI.Value()
+        try check(napi_create_double(ptr, value, &resultCouldBeBadOnWindows.ptr))
         try check(napi_create_double(ptr, value, &result.ptr))
         return result
     }

--- a/Sources/FishyJoesNodeRuntime/NAPI.swift
+++ b/Sources/FishyJoesNodeRuntime/NAPI.swift
@@ -268,9 +268,7 @@ extension NAPI.Env {
         return result
     }
     public func createDouble(_ value: Double) throws -> NAPI.Value {
-        var resultCouldBeBadOnWindows = NAPI.Value()
         var result = NAPI.Value()
-        try check(napi_create_double(ptr, value, &resultCouldBeBadOnWindows.ptr))
         try check(napi_create_double(ptr, value, &result.ptr))
         return result
     }

--- a/integration-tests/TestAPI-bindings/Sources/Generated/NodeInterface/TypeSetup.swift
+++ b/integration-tests/TestAPI-bindings/Sources/Generated/NodeInterface/TypeSetup.swift
@@ -255,6 +255,8 @@ public func registerModuleTestAPI(env: NAPI.Env, exports: NAPI.Value) throws -> 
     try Tuple6Converter<Swift.String, Swift.Int, Swift.Double, Tuple4Converter<Tuple2Converter<Swift.Int, Swift.String>, Tuple3Converter<Swift.String, Swift.Double, Swift.String>, Swift.String, Swift.Bool>, Tuple5Converter<Swift.String, Swift.UInt8, Tuple4Converter<Tuple2Converter<Swift.Int, Swift.String>, Tuple3Converter<Swift.String, Swift.Double, Swift.String>, Swift.String, Swift.Bool>, Tuple3Converter<Swift.String, Swift.Double, Swift.String>, Tuple2Converter<Swift.Int, Swift.String>>, Swift.Bool>.nodeSetup(env: env, module: module)
     try Tuple5Converter<Swift.String, Swift.UInt8, Tuple4Converter<Tuple2Converter<Swift.Int, Swift.String>, Tuple3Converter<Swift.String, Swift.Double, Swift.String>, Swift.String, Swift.Bool>, Tuple3Converter<Swift.String, Swift.Double, Swift.String>, Tuple2Converter<Swift.Int, Swift.String>>.nodeSetup(env: env, module: module)
     try Tuple4Converter<Tuple2Converter<Swift.Int, Swift.String>, Tuple3Converter<Swift.String, Swift.Double, Swift.String>, Swift.String, Swift.Bool>.nodeSetup(env: env, module: module)
+    // call once in TypeSetup to "prime the pump" so to speak aka work around a bug that may be related to win_delay_hook stuff put in by Stoker.
+    _ = try env.createDouble(42.0)
     try FishyJoesCommonRuntime.VoidConverter.nodeSetup(env: env, module: module)
     return exports
 }

--- a/integration-tests/TestAPI-bindings/Sources/Generated/NodeInterface/TypeSetup.swift
+++ b/integration-tests/TestAPI-bindings/Sources/Generated/NodeInterface/TypeSetup.swift
@@ -255,9 +255,9 @@ public func registerModuleTestAPI(env: NAPI.Env, exports: NAPI.Value) throws -> 
     try Tuple6Converter<Swift.String, Swift.Int, Swift.Double, Tuple4Converter<Tuple2Converter<Swift.Int, Swift.String>, Tuple3Converter<Swift.String, Swift.Double, Swift.String>, Swift.String, Swift.Bool>, Tuple5Converter<Swift.String, Swift.UInt8, Tuple4Converter<Tuple2Converter<Swift.Int, Swift.String>, Tuple3Converter<Swift.String, Swift.Double, Swift.String>, Swift.String, Swift.Bool>, Tuple3Converter<Swift.String, Swift.Double, Swift.String>, Tuple2Converter<Swift.Int, Swift.String>>, Swift.Bool>.nodeSetup(env: env, module: module)
     try Tuple5Converter<Swift.String, Swift.UInt8, Tuple4Converter<Tuple2Converter<Swift.Int, Swift.String>, Tuple3Converter<Swift.String, Swift.Double, Swift.String>, Swift.String, Swift.Bool>, Tuple3Converter<Swift.String, Swift.Double, Swift.String>, Tuple2Converter<Swift.Int, Swift.String>>.nodeSetup(env: env, module: module)
     try Tuple4Converter<Tuple2Converter<Swift.Int, Swift.String>, Tuple3Converter<Swift.String, Swift.Double, Swift.String>, Swift.String, Swift.Bool>.nodeSetup(env: env, module: module)
+    try FishyJoesCommonRuntime.VoidConverter.nodeSetup(env: env, module: module)
     // call once in TypeSetup to "prime the pump" so to speak aka work around a bug that may be related to win_delay_hook stuff put in by Stoker.
     _ = try env.createDouble(42.0)
-    try FishyJoesCommonRuntime.VoidConverter.nodeSetup(env: env, module: module)
     return exports
 }
 

--- a/integration-tests/TestAPI-bindings/node-test/Protocols.test.ts
+++ b/integration-tests/TestAPI-bindings/node-test/Protocols.test.ts
@@ -165,27 +165,32 @@ test('testProtocolStruct', () => {
 
 test('testProtocolClass', () => {
     const testProtocolClass = TestAPI.TestProtocolClass.init("Step inside it's a wilder ride!");
-    expect(testProtocolClass.corge).toEqual("Step inside it's a wilder ride!");
-    expect(testProtocolClass.frobby).toEqual([42, -1, 3]);
-    expect(testProtocolClass.flarp).toEqual(undefined);
-    testProtocolClass.flarp = "Excellent observation Kiki!";
-    expect(testProtocolClass.flarp).toEqual("Excellent observation Kiki!");
-    expect(testProtocolClass.wombat(undefined)).toEqual(42.909);
-    expect(testProtocolClass.wombat(57)).toEqual(undefined);
-    expect(testProtocolClass.wombat(56)).toEqual(7890.2);
 
-    expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.Thing(23947889))).toEqual(23947889);
-    expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.Other("zxc", 89708973))).toEqual(89708973);
-    expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.Bar("shme", new TestAPI.AssociatedDataEnum.NoValue()))).toEqual(45);
-    expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.NoValue())).toEqual(42);
-    expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.SimpleEnum("blue"))).toEqual(1);
+    for (let i=0; i < 10; i++) {
+        var w = testProtocolClass.wombat(undefined)
+        console.log("wombat: " + w);
+    }
+    // expect(testProtocolClass.corge).toEqual("Step inside it's a wilder ride!");
+    // expect(testProtocolClass.frobby).toEqual([42, -1, 3]);
+    // expect(testProtocolClass.flarp).toEqual(undefined);
+    // testProtocolClass.flarp = "Excellent observation Kiki!";
+    // expect(testProtocolClass.flarp).toEqual("Excellent observation Kiki!");
+    // expect(testProtocolClass.wombat(undefined)).toEqual(42.909);
+    // expect(testProtocolClass.wombat(57)).toEqual(undefined);
+    // expect(testProtocolClass.wombat(56)).toEqual(7890.2);
 
-    testProtocolClass.foo();
-    expect(testProtocolClass.bar()).toEqual(true);
-    testProtocolClass.baz(false);
-    expect(testProtocolClass.garply("Surfin' on a sine wave")).toEqual("garplify Surfin' on a sine wave parguino");
-    expect(testProtocolClass.xyzzy(42, [1.234, 45.235890198, 892.80])).toEqual("thud: 42 \\|/ grault: [1.234, 45.235890198, 892.8]");
-    expect(testProtocolClass.plugh([true, 92.47, ["Please let this be a normal field trip", "I knew I should've stayed home today"]])).toEqual([true, 83, "Please let this be a normal field trip _-^= I knew I should've stayed home today"]);
+    // expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.Thing(23947889))).toEqual(23947889);
+    // expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.Other("zxc", 89708973))).toEqual(89708973);
+    // expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.Bar("shme", new TestAPI.AssociatedDataEnum.NoValue()))).toEqual(45);
+    // expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.NoValue())).toEqual(42);
+    // expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.SimpleEnum("blue"))).toEqual(1);
+
+    // testProtocolClass.foo();
+    // expect(testProtocolClass.bar()).toEqual(true);
+    // testProtocolClass.baz(false);
+    // expect(testProtocolClass.garply("Surfin' on a sine wave")).toEqual("garplify Surfin' on a sine wave parguino");
+    // expect(testProtocolClass.xyzzy(42, [1.234, 45.235890198, 892.80])).toEqual("thud: 42 \\|/ grault: [1.234, 45.235890198, 892.8]");
+    // expect(testProtocolClass.plugh([true, 92.47, ["Please let this be a normal field trip", "I knew I should've stayed home today"]])).toEqual([true, 83, "Please let this be a normal field trip _-^= I knew I should've stayed home today"]);
 });
 
 test('testLeadingUnderscoreInNames', () => {

--- a/integration-tests/TestAPI-bindings/node-test/Protocols.test.ts
+++ b/integration-tests/TestAPI-bindings/node-test/Protocols.test.ts
@@ -166,31 +166,31 @@ test('testProtocolStruct', () => {
 test('testProtocolClass', () => {
     const testProtocolClass = TestAPI.TestProtocolClass.init("Step inside it's a wilder ride!");
 
-    for (let i=0; i < 10; i++) {
-        var w = testProtocolClass.wombat(undefined)
-        console.log("wombat: " + w);
-    }
-    // expect(testProtocolClass.corge).toEqual("Step inside it's a wilder ride!");
-    // expect(testProtocolClass.frobby).toEqual([42, -1, 3]);
-    // expect(testProtocolClass.flarp).toEqual(undefined);
-    // testProtocolClass.flarp = "Excellent observation Kiki!";
-    // expect(testProtocolClass.flarp).toEqual("Excellent observation Kiki!");
-    // expect(testProtocolClass.wombat(undefined)).toEqual(42.909);
-    // expect(testProtocolClass.wombat(57)).toEqual(undefined);
-    // expect(testProtocolClass.wombat(56)).toEqual(7890.2);
+    // for (let i=0; i < 10; i++) {
+    //     var w = testProtocolClass.wombat(undefined)
+    //     console.log("wombat: " + w);
+    // }
+    expect(testProtocolClass.corge).toEqual("Step inside it's a wilder ride!");
+    expect(testProtocolClass.frobby).toEqual([42, -1, 3]);
+    expect(testProtocolClass.flarp).toEqual(undefined);
+    testProtocolClass.flarp = "Excellent observation Kiki!";
+    expect(testProtocolClass.flarp).toEqual("Excellent observation Kiki!");
+    expect(testProtocolClass.wombat(undefined)).toEqual(42.909);
+    expect(testProtocolClass.wombat(57)).toEqual(undefined);
+    expect(testProtocolClass.wombat(56)).toEqual(7890.2);
 
-    // expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.Thing(23947889))).toEqual(23947889);
-    // expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.Other("zxc", 89708973))).toEqual(89708973);
-    // expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.Bar("shme", new TestAPI.AssociatedDataEnum.NoValue()))).toEqual(45);
-    // expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.NoValue())).toEqual(42);
-    // expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.SimpleEnum("blue"))).toEqual(1);
+    expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.Thing(23947889))).toEqual(23947889);
+    expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.Other("zxc", 89708973))).toEqual(89708973);
+    expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.Bar("shme", new TestAPI.AssociatedDataEnum.NoValue()))).toEqual(45);
+    expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.NoValue())).toEqual(42);
+    expect(testProtocolClass.spqr(new TestAPI.AssociatedDataEnum.SimpleEnum("blue"))).toEqual(1);
 
-    // testProtocolClass.foo();
-    // expect(testProtocolClass.bar()).toEqual(true);
-    // testProtocolClass.baz(false);
-    // expect(testProtocolClass.garply("Surfin' on a sine wave")).toEqual("garplify Surfin' on a sine wave parguino");
-    // expect(testProtocolClass.xyzzy(42, [1.234, 45.235890198, 892.80])).toEqual("thud: 42 \\|/ grault: [1.234, 45.235890198, 892.8]");
-    // expect(testProtocolClass.plugh([true, 92.47, ["Please let this be a normal field trip", "I knew I should've stayed home today"]])).toEqual([true, 83, "Please let this be a normal field trip _-^= I knew I should've stayed home today"]);
+    testProtocolClass.foo();
+    expect(testProtocolClass.bar()).toEqual(true);
+    testProtocolClass.baz(false);
+    expect(testProtocolClass.garply("Surfin' on a sine wave")).toEqual("garplify Surfin' on a sine wave parguino");
+    expect(testProtocolClass.xyzzy(42, [1.234, 45.235890198, 892.80])).toEqual("thud: 42 \\|/ grault: [1.234, 45.235890198, 892.8]");
+    expect(testProtocolClass.plugh([true, 92.47, ["Please let this be a normal field trip", "I knew I should've stayed home today"]])).toEqual([true, 83, "Please let this be a normal field trip _-^= I knew I should've stayed home today"]);
 });
 
 test('testLeadingUnderscoreInNames', () => {


### PR DESCRIPTION
because calling napi_create_double twice works on windows, just once won't do, for the first time there's some bug somewhere that clobbers the returned value from it.