### PR TITLE
AB#492339 Combine Generated Source files to work around Windows swift file source argument count limit

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -323,7 +323,7 @@ jobs:
 
       # Used to work around Windows number of source files limit (Just combine them into one large file).
       - name: Combine Generated Sources
-        shell: zsh {0}
+        shell: bash
         run: |
           set -euxo pipefail
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -75,6 +75,15 @@ jobs:
 
           ./scripts/compile-node-runtime.sh
 
+      # Used to work around Windows number of source files limit (Just combine them into one large file).
+      - name: Combine Generated Sources
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+
+          cd integration-tests/TestAPI-bindings
+          source combine_generated_sourches.sh TestAPI
+
       - name: Test TypeScript from npm via fishy-joes
         shell: zsh {0}
         run: |

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -75,15 +75,6 @@ jobs:
 
           ./scripts/compile-node-runtime.sh
 
-      # Used to work around Windows number of source files limit (Just combine them into one large file).
-      - name: Combine Generated Sources
-        shell: zsh {0}
-        run: |
-          set -euxo pipefail
-
-          cd integration-tests/TestAPI-bindings
-          source combine_generated_sourches.sh TestAPI
-
       - name: Test TypeScript from npm via fishy-joes
         shell: zsh {0}
         run: |
@@ -329,6 +320,15 @@ jobs:
           swift package resolve
           swift package resolve
           swift package resolve
+
+      # Used to work around Windows number of source files limit (Just combine them into one large file).
+      - name: Combine Generated Sources
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+
+          cd integration-tests/TestAPI-bindings
+          source combine_generated_sourches.sh TestAPI
 
       - name: Build FishyJoesNodeRuntime
         shell: bash

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -328,7 +328,7 @@ jobs:
           set -euxo pipefail
 
           cd integration-tests/TestAPI-bindings
-          source combine_generated_sourches.sh TestAPI
+          source combine_generated_sources.sh TestAPI
 
       - name: Build FishyJoesNodeRuntime
         shell: bash

--- a/integration-tests/TestAPI-bindings/combine_generated_sources.sh
+++ b/integration-tests/TestAPI-bindings/combine_generated_sources.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+
+if [[ $# -eq 0 ]] ; then
+    echo 'usage: ./combine_generated_sources.sh ModuleName'
+    echo 'ModuleName is name of your module we are generating bindings for such as TestAPI or CriGeo or Tesseract'
+    exit 0
+fi
+
+(
+    cd Sources/Generated/NodeInterface
+    cat $1.*.swift | grep import | sort | uniq > $1+node.swift
+    cat $1.*.swift | grep -v import >> $1+node.swift
+    rm $1.*.swift
+)
+
+(
+    cd Sources/Generated/JavaInterface
+    cat $1.*.swift | grep import | sort | uniq > $1+java.swift
+    cat $1.*.swift | grep -v import >> $1+java.swift
+    rm $1.*.swift
+)
+
+(
+    cd Sources/Generated/IotaInterface
+    cat $1.*.swift | grep import | sort | uniq > $1+iota.swift
+    cat $1.*.swift | grep -v import >> $1+iota.swift
+    rm $1.*.swift
+)


### PR DESCRIPTION
Combine Generated Source files to work around Windows swift file source argument count limit

Gotten from Konrad Rodzik's https://github.com/cricut/Tesseract-bindings/blob/main/combine_generated_sources.sh

https://cricut.visualstudio.com/Cricut/_workitems/edit/492339