### PR TITLE
fix nondeterminancy in module dependency order

### DIFF
--- a/Sources/FishyJoesCore/Module.swift
+++ b/Sources/FishyJoesCore/Module.swift
@@ -4,6 +4,11 @@ struct Module: Hashable, CustomStringConvertible, Codable {
     let name: String
     let dependencies: [String]
 
+    init(name: String, dependencies: [String]) {
+        self.name = name
+        self.dependencies = dependencies.sorted()
+    }
+
     var kotlinPackage: String { "com.cricut.\(name.lowercased())" }
     var cSharpNamespace: String { "Cricut.\(name)" }
     var dartNamespace: String { name }


### PR DESCRIPTION
Should fix this nondeterminancy: https://github.com/cricut/CriTrace-bindings/pull/39/files#diff-e67b85d7b74fd06060bbc1bf4eaa66e308fae5d1feb5db105b682b448a924071L451