### PR TITLE
Fix toString for Dart SwiftReferences. Add tests. Add toString to Node objects.

### DIFF
--- a/Sources/FishyJoesCore/TranslatedTypes/TranslatedReference.swift
+++ b/Sources/FishyJoesCore/TranslatedTypes/TranslatedReference.swift
@@ -133,6 +133,7 @@ struct TranslatedReference: TranslatedType {
 
             fragment.output("@available(*, deprecated, message: \"Not actually deprecated, but this silences warnings because it may refer to deprecated methods\")")
             fragment.outputBlock("public static func nodeSetup(env: NAPI.Env, module: NAPI.Value) throws {") {
+                // fragment.output("print(\"setting up \(sourceType.name)\")")
                 fragment.outputBlock("let nodeClass = try NodeClass(") {
                     fragment.output("env: env,")
                     fragment.output("name: \"\(nodeName)\",")
@@ -144,7 +145,7 @@ struct TranslatedReference: TranslatedType {
                             fragment.outputBlock(".method { env, info in", closeWith: "},") {
                                 fragment.outputBlock(#"FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in"#, closeWith: "}") {
                                     fragment.outputBlock("let result = try Swift.String.toNode(") {
-                                        fragment.output("\"\\(env.this(converter: \(sourceType.name).self))\",")
+                                        fragment.output("\"\\(env.this(converter: \(converterType.name).self))\",")
                                         fragment.output("env: env.env")
                                     }
                                     fragment.output("return result")

--- a/Sources/FishyJoesCore/TranslatedTypes/TranslatedReference.swift
+++ b/Sources/FishyJoesCore/TranslatedTypes/TranslatedReference.swift
@@ -144,7 +144,7 @@ struct TranslatedReference: TranslatedType {
                             fragment.outputBlock(".method { env, info in", closeWith: "},") {
                                 fragment.outputBlock(#"FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in"#, closeWith: "}") {
                                     fragment.outputBlock("let result = try Swift.String.toNode(") {
-                                        fragment.output(#""\(env.this(converter: TestAPI.EmptyClass.self))","#)
+                                        fragment.output("\"\\(env.this(converter: \(sourceType.name).self))\",")
                                         fragment.output("env: env.env")
                                     }
                                     fragment.output("return result")

--- a/Sources/FishyJoesCore/TranslatedTypes/TranslatedReference.swift
+++ b/Sources/FishyJoesCore/TranslatedTypes/TranslatedReference.swift
@@ -133,8 +133,6 @@ struct TranslatedReference: TranslatedType {
 
             fragment.output("@available(*, deprecated, message: \"Not actually deprecated, but this silences warnings because it may refer to deprecated methods\")")
             fragment.outputBlock("public static func nodeSetup(env: NAPI.Env, module: NAPI.Value) throws {") {
-                // fragment.output("print(\"setting up \(sourceType.name)\")")
-
                 fragment.outputBlock("let nodeClass = try NodeClass(") {
                     fragment.output("env: env,")
                     fragment.output("name: \"\(nodeName)\",")
@@ -142,8 +140,17 @@ struct TranslatedReference: TranslatedType {
                         var hasProperties = false
                         hasProperties ||= context.nodeTranslator.outputProperties(methods: methods, context: context, fragment: fragment, converterName: converterType.name)
                         hasProperties ||= context.nodeTranslator.outputProperties(computedVariables: computedVariables, context: context, fragment: fragment, converterName: converterType.name)
-                        if !hasProperties {
-                            fragment.output(":")
+                        fragment.outputBlock(#""toString": ("#) {
+                            fragment.outputBlock(".method { env, info in", closeWith: "},") {
+                                fragment.outputBlock(#"FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in"#, closeWith: "}") {
+                                    fragment.outputBlock("let result = try Swift.String.toNode(") {
+                                        fragment.output(#""\(env.this(converter: TestAPI.EmptyClass.self))","#)
+                                        fragment.output("env: env.env")
+                                    }
+                                    fragment.output("return result")
+                                }
+                            }
+                            fragment.output("isStatic: false")
                         }
                     }
                     fragment.outputBlock("constructor: { env, info in", closeWith: "}") {

--- a/Sources/FishyJoesCore/TranslatedTypes/TranslatedStruct.swift
+++ b/Sources/FishyJoesCore/TranslatedTypes/TranslatedStruct.swift
@@ -292,8 +292,6 @@ struct TranslatedStruct: TranslatedType {
 
         let generateMethodsForEmptyStruct = storedVariables.isEmpty
 
-        let (fieldsForGeneratedMethods, _) = KotlinClass.separate(fieldsAndMethods: fieldsAndMethods)
-
         if generateMethodsForEmptyStruct {
             var bodyBuilder = [String]()
 

--- a/Sources/FishyJoesCore/Unparse/DartProductClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartProductClass.swift
@@ -78,7 +78,7 @@ class DartProductClass: DartClass {
                 }
                 fragment.blankLine()
 
-                toStringImpl(fields: fields, fragment: fragment)
+                // Swift references handle toString through the dart runtime toString call to Swift on SwiftReference in utilities.dart
             case .public(let fields):
                 storedFields = fields
                 for field in fields {

--- a/Sources/FishyJoesCore/Unparse/DartProductClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartProductClass.swift
@@ -37,9 +37,7 @@ class DartProductClass: DartClass {
     private func toStringImpl(fields: [Variable], fragment: SourceFragment) {
         fragment.output("@override")
         fragment.output("String toString() => '\(module.name).\(unqualifiedName)(", newLineTerminated: false)
-        if unqualifiedName.contains("EmptyClass") {
-            let elegoo = 1
-        }
+
         let toStringParamsString = fields.filter {
             $0.name != "hashCode"
         }.map {

--- a/Sources/FishyJoesCore/Unparse/DartProductClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartProductClass.swift
@@ -37,7 +37,15 @@ class DartProductClass: DartClass {
     private func toStringImpl(fields: [Variable], fragment: SourceFragment) {
         fragment.output("@override")
         fragment.output("String toString() => '\(unqualifiedName)(", newLineTerminated: false)
-        let toStringParamsString = fields.map { "\(DartClass.deforbidify($0.name)): $\(DartClass.deforbidify($0.name))" }.joined(separator: ", ")
+        if unqualifiedName.contains("EmptyClass") {
+            let elegoo = 1
+        }
+        let toStringParamsString = fields.filter {
+            $0.name != "hashCode"
+        }.map {
+            "\(DartClass.deforbidify($0.name)): $\(DartClass.deforbidify($0.name))"
+        }.joined(separator: ", ")
+
         fragment.output("\(toStringParamsString))';")
 
         fragment.blankLine()

--- a/Sources/FishyJoesCore/Unparse/DartProductClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartProductClass.swift
@@ -36,7 +36,7 @@ class DartProductClass: DartClass {
 
     private func toStringImpl(fields: [Variable], fragment: SourceFragment) {
         fragment.output("@override")
-        fragment.output("String toString() => '\(unqualifiedName)(", newLineTerminated: false)
+        fragment.output("String toString() => '\(module.name).\(unqualifiedName)(", newLineTerminated: false)
         if unqualifiedName.contains("EmptyClass") {
             let elegoo = 1
         }

--- a/Sources/FishyJoesCore/Unparse/DartProductClass.swift
+++ b/Sources/FishyJoesCore/Unparse/DartProductClass.swift
@@ -38,9 +38,7 @@ class DartProductClass: DartClass {
         fragment.output("@override")
         fragment.output("String toString() => '\(module.name).\(unqualifiedName)(", newLineTerminated: false)
 
-        let toStringParamsString = fields.filter {
-            $0.name != "hashCode"
-        }.map {
+        let toStringParamsString = fields.map {
             "\(DartClass.deforbidify($0.name)): $\(DartClass.deforbidify($0.name))"
         }.joined(separator: ", ")
 

--- a/Sources/FishyJoesIotaRuntime/Box+Iota.swift
+++ b/Sources/FishyJoesIotaRuntime/Box+Iota.swift
@@ -39,8 +39,7 @@ public func AnyBoxRelease(envRef: EnvRef, ptr: UnsafeMutableRawPointer?, _ exn: 
 public func toString(envRef: EnvRef, ptr: UnsafeMutableRawPointer?, _ exn: foreignOutExn) -> foreignObject {
     let env = Env(envRef)
     return env.catching(to: exn) {
-        let this = AnyBox.takeUnretainedOpaque(try Env.unwrap(ptr))
-        return try String.toIota("\(this.value)", env: env)
+        try String.toIota("\(AnyBox.takeUnretainedOpaque(try Env.unwrap(ptr)).value)", env: env)
     }
 }
 

--- a/Sources/FishyJoesIotaRuntime/Box+Iota.swift
+++ b/Sources/FishyJoesIotaRuntime/Box+Iota.swift
@@ -39,7 +39,8 @@ public func AnyBoxRelease(envRef: EnvRef, ptr: UnsafeMutableRawPointer?, _ exn: 
 public func toString(envRef: EnvRef, ptr: UnsafeMutableRawPointer?, _ exn: foreignOutExn) -> foreignObject {
     let env = Env(envRef)
     return env.catching(to: exn) {
-        try String.toIota("\(AnyBox.takeUnretainedOpaque(try Env.unwrap(ptr)).value)", env: env)
+        let this = AnyBox.takeUnretainedOpaque(try Env.unwrap(ptr))
+        return try String.toIota("\(this.value)", env: env)
     }
 }
 

--- a/Sources/FishyJoesJavaRuntime/Box+Java.swift
+++ b/Sources/FishyJoesJavaRuntime/Box+Java.swift
@@ -36,7 +36,8 @@ extension AnyBox {
 
     private static let toString: @convention(c) (UnsafeMutablePointer<JNIEnv?>, jobject) -> jobject? = { env, this in
         callbackBody(env) { env in
-            try String.toJava("\(fromJava(this, env: env).value)", env: env)
+            let this = try fromJava(this, env: env)
+            return try String.toJava("\(this.value)", env: env)
         }
     }
 

--- a/Sources/FishyJoesJavaRuntime/Box+Java.swift
+++ b/Sources/FishyJoesJavaRuntime/Box+Java.swift
@@ -36,8 +36,7 @@ extension AnyBox {
 
     private static let toString: @convention(c) (UnsafeMutablePointer<JNIEnv?>, jobject) -> jobject? = { env, this in
         callbackBody(env) { env in
-            let this = try fromJava(this, env: env)
-            return try String.toJava("\(this.value)", env: env)
+            try String.toJava("\(fromJava(this, env: env).value)", env: env)
         }
     }
 

--- a/dart-runtime/lib/swift_reference.dart
+++ b/dart-runtime/lib/swift_reference.dart
@@ -20,6 +20,10 @@ class SwiftReference {
     }
   }
 
+  String toString() {
+    return check((exn) => consumeCreatedRef<String>(Loader.fishyJoesCommonRuntime_AnyBox_toString(Loader.shared.env, unsafeReference.cast(), exn)));
+  }
+
   static CreatedRef constructor(ffi.Pointer ptr, OutCreatedRef exn) =>
     catchingRef(exn, () => createRef(SwiftReference(ptr)));
 

--- a/integration-tests/TestAPI-bindings/Sources/Generated/NodeInterface/TestAPI+node.swift
+++ b/integration-tests/TestAPI-bindings/Sources/Generated/NodeInterface/TestAPI+node.swift
@@ -719,6 +719,18 @@ extension TestAPI.Actors.TemperatureLogger: FishyJoesNodeRuntime.NodeConverter {
                     ),
                     isStatic: false
                 ),
+                "toString": (
+                    .method { env, info in
+                        FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
+                            let result = try Swift.String.toNode(
+                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                env: env.env
+                            )
+                            return result
+                        }
+                    },
+                    isStatic: false
+                )
             ],
             constructor: { env, info in
                 FishyJoesNodeRuntime.callbackBody(env, info, name: "Actors.TemperatureLogger_constructor", expectedArgumentCount: 1) { env in
@@ -2648,6 +2660,18 @@ extension TestAPI.EmptyClass: FishyJoesNodeRuntime.NodeConverter {
                     ),
                     isStatic: false
                 ),
+                "toString": (
+                    .method { env, info in
+                        FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
+                            let result = try Swift.String.toNode(
+                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                env: env.env
+                            )
+                            return result
+                        }
+                    },
+                    isStatic: false
+                )
             ],
             constructor: { env, info in
                 FishyJoesNodeRuntime.callbackBody(env, info, name: "EmptyClass1_constructor", expectedArgumentCount: 1) { env in
@@ -2753,6 +2777,18 @@ extension TestAPI.EmptyClass2: FishyJoesNodeRuntime.NodeConverter {
                     ),
                     isStatic: false
                 ),
+                "toString": (
+                    .method { env, info in
+                        FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
+                            let result = try Swift.String.toNode(
+                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                env: env.env
+                            )
+                            return result
+                        }
+                    },
+                    isStatic: false
+                )
             ],
             constructor: { env, info in
                 FishyJoesNodeRuntime.callbackBody(env, info, name: "EmptyClass2_constructor", expectedArgumentCount: 1) { env in
@@ -3945,6 +3981,18 @@ extension TestAPI.Methods: FishyJoesNodeRuntime.NodeConverter {
                         }),
                     isStatic: true
                 ),
+                "toString": (
+                    .method { env, info in
+                        FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
+                            let result = try Swift.String.toNode(
+                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                env: env.env
+                            )
+                            return result
+                        }
+                    },
+                    isStatic: false
+                )
             ],
             constructor: { env, info in
                 FishyJoesNodeRuntime.callbackBody(env, info, name: "Methods_constructor", expectedArgumentCount: 1) { env in
@@ -6360,6 +6408,18 @@ extension TestAPI.Structs.PuttingTypesIntoQuestionablePlaces: FishyJoesNodeRunti
                     },
                     isStatic: false
                 ),
+                "toString": (
+                    .method { env, info in
+                        FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
+                            let result = try Swift.String.toNode(
+                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                env: env.env
+                            )
+                            return result
+                        }
+                    },
+                    isStatic: false
+                )
             ],
             constructor: { env, info in
                 FishyJoesNodeRuntime.callbackBody(env, info, name: "Structs_PuttingTypesIntoQuestionablePlaces_constructor", expectedArgumentCount: 1) { env in
@@ -6476,6 +6536,18 @@ extension TestAPI.Structs.ReferenceStruct: FishyJoesNodeRuntime.NodeConverter {
                         }),
                     isStatic: false
                 ),
+                "toString": (
+                    .method { env, info in
+                        FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
+                            let result = try Swift.String.toNode(
+                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                env: env.env
+                            )
+                            return result
+                        }
+                    },
+                    isStatic: false
+                )
             ],
             constructor: { env, info in
                 FishyJoesNodeRuntime.callbackBody(env, info, name: "Structs.ReferenceStruct_constructor", expectedArgumentCount: 1) { env in
@@ -7975,6 +8047,18 @@ extension TestAPI.TestAsyncSwiftSideFunctionsClass: FishyJoesNodeRuntime.NodeCon
                     ),
                     isStatic: false
                 ),
+                "toString": (
+                    .method { env, info in
+                        FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
+                            let result = try Swift.String.toNode(
+                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                env: env.env
+                            )
+                            return result
+                        }
+                    },
+                    isStatic: false
+                )
             ],
             constructor: { env, info in
                 FishyJoesNodeRuntime.callbackBody(env, info, name: "TestAsyncSwiftSideFunctionsClass_constructor", expectedArgumentCount: 1) { env in
@@ -8241,6 +8325,18 @@ extension TestAPI.TestDefaultComputedPropertiesClass: FishyJoesNodeRuntime.NodeC
                         }),
                     isStatic: false
                 ),
+                "toString": (
+                    .method { env, info in
+                        FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
+                            let result = try Swift.String.toNode(
+                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                env: env.env
+                            )
+                            return result
+                        }
+                    },
+                    isStatic: false
+                )
             ],
             constructor: { env, info in
                 FishyJoesNodeRuntime.callbackBody(env, info, name: "TestDefaultComputedPropertiesReference_constructor", expectedArgumentCount: 1) { env in
@@ -9364,6 +9460,18 @@ extension TestAPI.TestProtocolClass: FishyJoesNodeRuntime.NodeConverter {
                     ),
                     isStatic: false
                 ),
+                "toString": (
+                    .method { env, info in
+                        FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
+                            let result = try Swift.String.toNode(
+                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                env: env.env
+                            )
+                            return result
+                        }
+                    },
+                    isStatic: false
+                )
             ],
             constructor: { env, info in
                 FishyJoesNodeRuntime.callbackBody(env, info, name: "TestProtocolClass_constructor", expectedArgumentCount: 1) { env in

--- a/integration-tests/TestAPI-bindings/Sources/Generated/NodeInterface/TestAPI+node.swift
+++ b/integration-tests/TestAPI-bindings/Sources/Generated/NodeInterface/TestAPI+node.swift
@@ -723,7 +723,7 @@ extension TestAPI.Actors.TemperatureLogger: FishyJoesNodeRuntime.NodeConverter {
                     .method { env, info in
                         FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
                             let result = try Swift.String.toNode(
-                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                "\(env.this(converter: TestAPI.Actors.TemperatureLogger.self))",
                                 env: env.env
                             )
                             return result
@@ -2781,7 +2781,7 @@ extension TestAPI.EmptyClass2: FishyJoesNodeRuntime.NodeConverter {
                     .method { env, info in
                         FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
                             let result = try Swift.String.toNode(
-                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                "\(env.this(converter: TestAPI.EmptyClass2.self))",
                                 env: env.env
                             )
                             return result
@@ -3985,7 +3985,7 @@ extension TestAPI.Methods: FishyJoesNodeRuntime.NodeConverter {
                     .method { env, info in
                         FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
                             let result = try Swift.String.toNode(
-                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                "\(env.this(converter: TestAPI.Methods.self))",
                                 env: env.env
                             )
                             return result
@@ -6412,7 +6412,7 @@ extension TestAPI.Structs.PuttingTypesIntoQuestionablePlaces: FishyJoesNodeRunti
                     .method { env, info in
                         FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
                             let result = try Swift.String.toNode(
-                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                "\(env.this(converter: TestAPI.Structs.PuttingTypesIntoQuestionablePlaces.self))",
                                 env: env.env
                             )
                             return result
@@ -6540,7 +6540,7 @@ extension TestAPI.Structs.ReferenceStruct: FishyJoesNodeRuntime.NodeConverter {
                     .method { env, info in
                         FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
                             let result = try Swift.String.toNode(
-                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                "\(env.this(converter: TestAPI.Structs.ReferenceStruct.self))",
                                 env: env.env
                             )
                             return result
@@ -8051,7 +8051,7 @@ extension TestAPI.TestAsyncSwiftSideFunctionsClass: FishyJoesNodeRuntime.NodeCon
                     .method { env, info in
                         FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
                             let result = try Swift.String.toNode(
-                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                "\(env.this(converter: TestAPI.TestAsyncSwiftSideFunctionsClass.self))",
                                 env: env.env
                             )
                             return result
@@ -8329,7 +8329,7 @@ extension TestAPI.TestDefaultComputedPropertiesClass: FishyJoesNodeRuntime.NodeC
                     .method { env, info in
                         FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
                             let result = try Swift.String.toNode(
-                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                "\(env.this(converter: TestAPI.TestDefaultComputedPropertiesClass.self))",
                                 env: env.env
                             )
                             return result
@@ -9464,7 +9464,7 @@ extension TestAPI.TestProtocolClass: FishyJoesNodeRuntime.NodeConverter {
                     .method { env, info in
                         FishyJoesNodeRuntime.callbackBody(env, info, name: "toString", expectedArgumentCount: 0, hasNamedOptions: false) { env in
                             let result = try Swift.String.toNode(
-                                "\(env.this(converter: TestAPI.EmptyClass.self))",
+                                "\(env.this(converter: TestAPI.TestProtocolClass.self))",
                                 env: env.env
                             )
                             return result

--- a/integration-tests/TestAPI-bindings/c-sharp/Cricut.TestAPI.Tests/AttributedStringTests.cs
+++ b/integration-tests/TestAPI-bindings/c-sharp/Cricut.TestAPI.Tests/AttributedStringTests.cs
@@ -496,9 +496,14 @@ namespace Cricut.TestAPI.Tests {
             // TODO: implement copyWith for c#?
 
             Assert.Equal("quxx", a1.X);
+            Assert.Equal("quxx", a2.X);
             Assert.Equal("corgle", b1.X);
+            Assert.Equal("garply", b2.X);
 
             Assert.Equal("AttributedString_PuttingTypesIntoQuestionablePlaces { X = quxx }", a1.ToString());
+            Assert.Equal("AttributedString_PuttingTypesIntoQuestionablePlaces { X = quxx }", a2.ToString());
+            Assert.Equal("AttributedString_PuttingTypesIntoQuestionablePlaces { X = corgle }", b1.ToString());
+            Assert.Equal("AttributedString_PuttingTypesIntoQuestionablePlaces { X = garply }", b2.ToString());
 
             Assert.Equal(a1.GetHashCode(), a2.GetHashCode());
             Assert.NotEqual(b1.GetHashCode(), b2.GetHashCode());

--- a/integration-tests/TestAPI-bindings/c-sharp/Cricut.TestAPI.Tests/AttributedStringTests.cs
+++ b/integration-tests/TestAPI-bindings/c-sharp/Cricut.TestAPI.Tests/AttributedStringTests.cs
@@ -485,5 +485,28 @@ namespace Cricut.TestAPI.Tests {
             Assert.Single(runRanges);
             Assert.Equal(new AttributedString("Hello Olá こんにちは"), attributedString);
         }
+
+        [Fact]
+        void testAttributedStringPuttingTypesIntoQuestionablePlaces() {
+            var a1 = new AttributedString_PuttingTypesIntoQuestionablePlaces("quxx");
+            var a2 = new AttributedString_PuttingTypesIntoQuestionablePlaces("quxx");
+            var b1 = new AttributedString_PuttingTypesIntoQuestionablePlaces("corgle");
+            var b2 = new AttributedString_PuttingTypesIntoQuestionablePlaces("garply");
+
+            // TODO: implement copyWith for c#?
+
+            Assert.Equal("quxx", a1.X);
+            Assert.Equal("corgle", b1.X);
+
+            Assert.Equal("AttributedString_PuttingTypesIntoQuestionablePlaces { X = quxx }", a1.ToString());
+
+            Assert.Equal(a1.GetHashCode(), a2.GetHashCode());
+            Assert.NotEqual(b1.GetHashCode(), b2.GetHashCode());
+
+            Assert.Equal(42, a1.TestCall());
+            Assert.Equal(42, a2.TestCall());
+            Assert.Equal(42, b1.TestCall());
+            Assert.Equal(42, b2.TestCall());
+        }
     }
 }

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/AProtocolImplementation.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/AProtocolImplementation.dart
@@ -100,7 +100,7 @@ class AProtocolImplementation implements TestAPI.AProtocol {
         ))
     );
     @override
-    String toString() => 'AProtocolImplementation(foo: $foo, baz: $baz)';
+    String toString() => 'TestAPI.AProtocolImplementation(foo: $foo, baz: $baz)';
 
     static CreatedRef ffi_get_foo(
         UnownedRef obj,

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Actors_TemperatureLogger.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Actors_TemperatureLogger.dart
@@ -85,7 +85,7 @@ class Actors_TemperatureLogger extends SwiftReference {
     );
 
     @override
-    String toString() => 'Actors_TemperatureLogger(backwardsLabel: $backwardsLabel, extensionNonisolatedVarLabel: $extensionNonisolatedVarLabel, label: $label)';
+    String toString() => 'TestAPI.Actors_TemperatureLogger(backwardsLabel: $backwardsLabel, extensionNonisolatedVarLabel: $extensionNonisolatedVarLabel, label: $label)';
 
     /// <!-- FishyJoes.export(backwardsLabel) -->
     String get backwardsLabel =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Actors_TemperatureLogger.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Actors_TemperatureLogger.dart
@@ -84,9 +84,6 @@ class Actors_TemperatureLogger extends SwiftReference {
         createRef(Actors_TemperatureLogger(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.Actors_TemperatureLogger(backwardsLabel: $backwardsLabel, extensionNonisolatedVarLabel: $extensionNonisolatedVarLabel, label: $label)';
-
     /// <!-- FishyJoes.export(backwardsLabel) -->
     String get backwardsLabel =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/AttributedString_PuttingTypesIntoQuestionablePlaces.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/AttributedString_PuttingTypesIntoQuestionablePlaces.dart
@@ -95,7 +95,7 @@ class AttributedString_PuttingTypesIntoQuestionablePlaces {
         ))
     );
     @override
-    String toString() => 'AttributedString_PuttingTypesIntoQuestionablePlaces(x: $x)';
+    String toString() => 'TestAPI.AttributedString_PuttingTypesIntoQuestionablePlaces(x: $x)';
 
     static CreatedRef ffi_get_x(
         UnownedRef obj,

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Collections_CollectionHolder.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Collections_CollectionHolder.dart
@@ -135,7 +135,7 @@ class Collections_CollectionHolder {
         ))
     );
     @override
-    String toString() => 'Collections_CollectionHolder(boolArray: $boolArray, boolSet: $boolSet, boolDictionary: $boolDictionary, integerArray: $integerArray, integerSet: $integerSet, integerDictionary: $integerDictionary, stringArray: $stringArray, stringSet: $stringSet, stringDictionary: $stringDictionary)';
+    String toString() => 'TestAPI.Collections_CollectionHolder(boolArray: $boolArray, boolSet: $boolSet, boolDictionary: $boolDictionary, integerArray: $integerArray, integerSet: $integerSet, integerDictionary: $integerDictionary, stringArray: $stringArray, stringSet: $stringSet, stringDictionary: $stringDictionary)';
 
     static CreatedRef ffi_get_boolArray(
         UnownedRef obj,

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyClass1.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyClass1.dart
@@ -85,7 +85,7 @@ class EmptyClass1 extends SwiftReference {
     );
 
     @override
-    String toString() => 'EmptyClass1(blarg: $blarg, wibbledyWobbledyTimeyWhimey: $wibbledyWobbledyTimeyWhimey, hashCode: $hashCode)';
+    String toString() => 'EmptyClass1(blarg: $blarg, wibbledyWobbledyTimeyWhimey: $wibbledyWobbledyTimeyWhimey)';
 
     /// <!-- FishyJoes.export(blarg) -->
     String get blarg =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyClass1.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyClass1.dart
@@ -84,9 +84,6 @@ class EmptyClass1 extends SwiftReference {
         createRef(EmptyClass1(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.EmptyClass1(blarg: $blarg, wibbledyWobbledyTimeyWhimey: $wibbledyWobbledyTimeyWhimey)';
-
     /// <!-- FishyJoes.export(blarg) -->
     String get blarg =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyClass1.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyClass1.dart
@@ -85,7 +85,7 @@ class EmptyClass1 extends SwiftReference {
     );
 
     @override
-    String toString() => 'EmptyClass1(blarg: $blarg, wibbledyWobbledyTimeyWhimey: $wibbledyWobbledyTimeyWhimey)';
+    String toString() => 'TestAPI.EmptyClass1(blarg: $blarg, wibbledyWobbledyTimeyWhimey: $wibbledyWobbledyTimeyWhimey)';
 
     /// <!-- FishyJoes.export(blarg) -->
     String get blarg =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyClass2.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyClass2.dart
@@ -84,9 +84,6 @@ class EmptyClass2 extends SwiftReference {
         createRef(EmptyClass2(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.EmptyClass2(blorg: $blorg, wibble: $wibble)';
-
     /// <!-- FishyJoes.export(blorg) -->
     String get blorg =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyClass2.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyClass2.dart
@@ -85,7 +85,7 @@ class EmptyClass2 extends SwiftReference {
     );
 
     @override
-    String toString() => 'EmptyClass2(blorg: $blorg, wibble: $wibble, hashCode: $hashCode)';
+    String toString() => 'EmptyClass2(blorg: $blorg, wibble: $wibble)';
 
     /// <!-- FishyJoes.export(blorg) -->
     String get blorg =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyClass2.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyClass2.dart
@@ -85,7 +85,7 @@ class EmptyClass2 extends SwiftReference {
     );
 
     @override
-    String toString() => 'EmptyClass2(blorg: $blorg, wibble: $wibble)';
+    String toString() => 'TestAPI.EmptyClass2(blorg: $blorg, wibble: $wibble)';
 
     /// <!-- FishyJoes.export(blorg) -->
     String get blorg =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyStruct.dart
@@ -90,7 +90,7 @@ class EmptyStruct {
         ))
     );
     @override
-    String toString() => 'EmptyStruct()';
+    String toString() => 'TestAPI.EmptyStruct()';
 
     @override
     bool operator ==(Object other) {

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyStruct2.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/EmptyStruct2.dart
@@ -90,7 +90,7 @@ class EmptyStruct2 {
         ))
     );
     @override
-    String toString() => 'EmptyStruct2()';
+    String toString() => 'TestAPI.EmptyStruct2()';
 
     @override
     bool operator ==(Object other) {

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_AProtocol.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_AProtocol.dart
@@ -85,7 +85,7 @@ class ExternalWitness_AProtocol extends SwiftReference implements TestAPI.AProto
     );
 
     @override
-    String toString() => 'ExternalWitness_AProtocol(baz: $baz, foo: $foo)';
+    String toString() => 'TestAPI.ExternalWitness_AProtocol(baz: $baz, foo: $foo)';
 
     /// <!-- FishyJoes.export(baz) -->
     bool get baz =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_AProtocol.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_AProtocol.dart
@@ -84,9 +84,6 @@ class ExternalWitness_AProtocol extends SwiftReference implements TestAPI.AProto
         createRef(ExternalWitness_AProtocol(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.ExternalWitness_AProtocol(baz: $baz, foo: $foo)';
-
     /// <!-- FishyJoes.export(baz) -->
     bool get baz =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestAsyncFunctions.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestAsyncFunctions.dart
@@ -85,7 +85,7 @@ class ExternalWitness_TestAsyncFunctions extends SwiftReference implements TestA
     );
 
     @override
-    String toString() => 'ExternalWitness_TestAsyncFunctions(add3Things: $add3Things, const42: $const42, fifthThing: $fifthThing, iabs: $iabs, intCompose: $intCompose, makeList: $makeList, six: $six, willThrow: $willThrow)';
+    String toString() => 'TestAPI.ExternalWitness_TestAsyncFunctions(add3Things: $add3Things, const42: $const42, fifthThing: $fifthThing, iabs: $iabs, intCompose: $intCompose, makeList: $makeList, six: $six, willThrow: $willThrow)';
 
     /// <!-- FishyJoes.export(add3Things) -->
     Future<double> Function(double, double, int) get add3Things =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestAsyncFunctions.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestAsyncFunctions.dart
@@ -84,9 +84,6 @@ class ExternalWitness_TestAsyncFunctions extends SwiftReference implements TestA
         createRef(ExternalWitness_TestAsyncFunctions(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.ExternalWitness_TestAsyncFunctions(add3Things: $add3Things, const42: $const42, fifthThing: $fifthThing, iabs: $iabs, intCompose: $intCompose, makeList: $makeList, six: $six, willThrow: $willThrow)';
-
     /// <!-- FishyJoes.export(add3Things) -->
     Future<double> Function(double, double, int) get add3Things =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestDefaultComputedProperties.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestDefaultComputedProperties.dart
@@ -85,7 +85,7 @@ class ExternalWitness_TestDefaultComputedProperties extends SwiftReference imple
     );
 
     @override
-    String toString() => 'ExternalWitness_TestDefaultComputedProperties(noot: $noot, plutonic: $plutonic)';
+    String toString() => 'TestAPI.ExternalWitness_TestDefaultComputedProperties(noot: $noot, plutonic: $plutonic)';
 
     /// <!-- FishyJoes.export(noot) -->
     int get noot =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestDefaultComputedProperties.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestDefaultComputedProperties.dart
@@ -84,9 +84,6 @@ class ExternalWitness_TestDefaultComputedProperties extends SwiftReference imple
         createRef(ExternalWitness_TestDefaultComputedProperties(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.ExternalWitness_TestDefaultComputedProperties(noot: $noot, plutonic: $plutonic)';
-
     /// <!-- FishyJoes.export(noot) -->
     int get noot =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestDifferingExportNameProtocolDiffy.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestDifferingExportNameProtocolDiffy.dart
@@ -85,7 +85,7 @@ class ExternalWitness_TestDifferingExportNameProtocolDiffy extends SwiftReferenc
     );
 
     @override
-    String toString() => 'ExternalWitness_TestDifferingExportNameProtocolDiffy(tata: $tata)';
+    String toString() => 'TestAPI.ExternalWitness_TestDifferingExportNameProtocolDiffy(tata: $tata)';
 
     /// <!-- FishyJoes.export(tata) -->
     int get tata =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestDifferingExportNameProtocolDiffy.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestDifferingExportNameProtocolDiffy.dart
@@ -84,9 +84,6 @@ class ExternalWitness_TestDifferingExportNameProtocolDiffy extends SwiftReferenc
         createRef(ExternalWitness_TestDifferingExportNameProtocolDiffy(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.ExternalWitness_TestDifferingExportNameProtocolDiffy(tata: $tata)';
-
     /// <!-- FishyJoes.export(tata) -->
     int get tata =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestLeadingUnderscoredProp.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestLeadingUnderscoredProp.dart
@@ -85,7 +85,7 @@ class ExternalWitness_TestLeadingUnderscoredProp extends SwiftReference implemen
     );
 
     @override
-    String toString() => 'ExternalWitness_TestLeadingUnderscoredProp(m_leadingUnderscoreProp: $m_leadingUnderscoreProp)';
+    String toString() => 'TestAPI.ExternalWitness_TestLeadingUnderscoredProp(m_leadingUnderscoreProp: $m_leadingUnderscoreProp)';
 
     /// <!-- FishyJoes.export(_leadingUnderscoreProp) -->
     String get m_leadingUnderscoreProp =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestLeadingUnderscoredProp.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestLeadingUnderscoredProp.dart
@@ -84,9 +84,6 @@ class ExternalWitness_TestLeadingUnderscoredProp extends SwiftReference implemen
         createRef(ExternalWitness_TestLeadingUnderscoredProp(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.ExternalWitness_TestLeadingUnderscoredProp(m_leadingUnderscoreProp: $m_leadingUnderscoreProp)';
-
     /// <!-- FishyJoes.export(_leadingUnderscoreProp) -->
     String get m_leadingUnderscoreProp =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestMethodsProtocol.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestMethodsProtocol.dart
@@ -85,7 +85,7 @@ class ExternalWitness_TestMethodsProtocol extends SwiftReference implements Test
     );
 
     @override
-    String toString() => 'ExternalWitness_TestMethodsProtocol()';
+    String toString() => 'TestAPI.ExternalWitness_TestMethodsProtocol()';
 
     /// <!-- FishyJoes.export(foo) -->
     void foo(

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestMethodsProtocol.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestMethodsProtocol.dart
@@ -84,9 +84,6 @@ class ExternalWitness_TestMethodsProtocol extends SwiftReference implements Test
         createRef(ExternalWitness_TestMethodsProtocol(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.ExternalWitness_TestMethodsProtocol()';
-
     /// <!-- FishyJoes.export(foo) -->
     void foo(
     ) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestOptionalsProtocol.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestOptionalsProtocol.dart
@@ -84,9 +84,6 @@ class ExternalWitness_TestOptionalsProtocol extends SwiftReference implements Te
         createRef(ExternalWitness_TestOptionalsProtocol(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.ExternalWitness_TestOptionalsProtocol(flarp: $flarp)';
-
     /// <!-- FishyJoes.export(flarp) -->
     String? get flarp =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestOptionalsProtocol.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestOptionalsProtocol.dart
@@ -85,7 +85,7 @@ class ExternalWitness_TestOptionalsProtocol extends SwiftReference implements Te
     );
 
     @override
-    String toString() => 'ExternalWitness_TestOptionalsProtocol(flarp: $flarp)';
+    String toString() => 'TestAPI.ExternalWitness_TestOptionalsProtocol(flarp: $flarp)';
 
     /// <!-- FishyJoes.export(flarp) -->
     String? get flarp =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestPropertiesProtocol.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestPropertiesProtocol.dart
@@ -84,9 +84,6 @@ class ExternalWitness_TestPropertiesProtocol extends SwiftReference implements T
         createRef(ExternalWitness_TestPropertiesProtocol(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.ExternalWitness_TestPropertiesProtocol(corge: $corge, frobby: $frobby)';
-
     /// <!-- FishyJoes.export(corge) -->
     String get corge =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestPropertiesProtocol.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/ExternalWitness_TestPropertiesProtocol.dart
@@ -85,7 +85,7 @@ class ExternalWitness_TestPropertiesProtocol extends SwiftReference implements T
     );
 
     @override
-    String toString() => 'ExternalWitness_TestPropertiesProtocol(corge: $corge, frobby: $frobby)';
+    String toString() => 'TestAPI.ExternalWitness_TestPropertiesProtocol(corge: $corge, frobby: $frobby)';
 
     /// <!-- FishyJoes.export(corge) -->
     String get corge =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Methods.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Methods.dart
@@ -84,9 +84,6 @@ class Methods extends SwiftReference {
         createRef(Methods(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.Methods(garply: $garply, instanceGet: $instanceGet, instanceGetMethod: $instanceGetMethod, instanceModifiable: $instanceModifiable, instanceStored: $instanceStored, staticGet: $staticGet, staticGetMethod: $staticGetMethod, staticModifiable: $staticModifiable, staticStored: $staticStored)';
-
     /// <!-- FishyJoes.export(garply) -->
     int get garply =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Methods.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Methods.dart
@@ -85,7 +85,7 @@ class Methods extends SwiftReference {
     );
 
     @override
-    String toString() => 'Methods(garply: $garply, instanceGet: $instanceGet, instanceGetMethod: $instanceGetMethod, instanceModifiable: $instanceModifiable, instanceStored: $instanceStored, staticGet: $staticGet, staticGetMethod: $staticGetMethod, staticModifiable: $staticModifiable, staticStored: $staticStored)';
+    String toString() => 'TestAPI.Methods(garply: $garply, instanceGet: $instanceGet, instanceGetMethod: $instanceGetMethod, instanceModifiable: $instanceModifiable, instanceStored: $instanceStored, staticGet: $staticGet, staticGetMethod: $staticGetMethod, staticModifiable: $staticModifiable, staticStored: $staticStored)';
 
     /// <!-- FishyJoes.export(garply) -->
     int get garply =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Primitives_PrimitiveHolder.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Primitives_PrimitiveHolder.dart
@@ -220,7 +220,7 @@ class Primitives_PrimitiveHolder {
         ))
     );
     @override
-    String toString() => 'Primitives_PrimitiveHolder(b: $b, bq: $bq, ui8: $ui8, ui8q: $ui8q, ui16: $ui16, ui16q: $ui16q, ui32: $ui32, ui32q: $ui32q, ui64: $ui64, ui64q: $ui64q, ui: $ui, uiq: $uiq, i8: $i8, i8q: $i8q, i16: $i16, i16q: $i16q, i32: $i32, i32q: $i32q, i64: $i64, i64q: $i64q, i: $i, iq: $iq, f: $f, fq: $fq, d: $d, dq: $dq)';
+    String toString() => 'TestAPI.Primitives_PrimitiveHolder(b: $b, bq: $bq, ui8: $ui8, ui8q: $ui8q, ui16: $ui16, ui16q: $ui16q, ui32: $ui32, ui32q: $ui32q, ui64: $ui64, ui64q: $ui64q, ui: $ui, uiq: $uiq, i8: $i8, i8q: $i8q, i16: $i16, i16q: $i16q, i32: $i32, i32q: $i32q, i64: $i64, i64q: $i64q, i: $i, iq: $iq, f: $f, fq: $fq, d: $d, dq: $dq)';
 
     static bool ffi_get_b(
         UnownedRef obj,

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Results_Error.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Results_Error.dart
@@ -95,7 +95,7 @@ class Results_Error {
         ))
     );
     @override
-    String toString() => 'Results_Error(message: $message)';
+    String toString() => 'TestAPI.Results_Error(message: $message)';
 
     static CreatedRef ffi_get_message(
         UnownedRef obj,

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/String_PuttingTypesIntoQuestionablePlaces.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/String_PuttingTypesIntoQuestionablePlaces.dart
@@ -95,7 +95,7 @@ class String_PuttingTypesIntoQuestionablePlaces {
         ))
     );
     @override
-    String toString() => 'String_PuttingTypesIntoQuestionablePlaces(x: $x)';
+    String toString() => 'TestAPI.String_PuttingTypesIntoQuestionablePlaces(x: $x)';
 
     static CreatedRef ffi_get_x(
         UnownedRef obj,

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_MemberwiseStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_MemberwiseStruct.dart
@@ -101,7 +101,7 @@ class Structs_MemberwiseStruct {
         ))
     );
     @override
-    String toString() => 'Structs_MemberwiseStruct(immutable: $immutable, mutable: $mutable)';
+    String toString() => 'TestAPI.Structs_MemberwiseStruct(immutable: $immutable, mutable: $mutable)';
 
     static CreatedRef ffi_get_immutable(
         UnownedRef obj,

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_MutableStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_MutableStruct.dart
@@ -95,7 +95,7 @@ class Structs_MutableStruct {
         ))
     );
     @override
-    String toString() => 'Structs_MutableStruct(i: $i)';
+    String toString() => 'TestAPI.Structs_MutableStruct(i: $i)';
 
     static int ffi_get_i(
         UnownedRef obj,

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_PuttingTypesIntoQuestionablePlaces.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_PuttingTypesIntoQuestionablePlaces.dart
@@ -85,7 +85,7 @@ class Structs_PuttingTypesIntoQuestionablePlaces extends SwiftReference {
     );
 
     @override
-    String toString() => 'Structs_PuttingTypesIntoQuestionablePlaces()';
+    String toString() => 'TestAPI.Structs_PuttingTypesIntoQuestionablePlaces()';
 
     /// <!-- FishyJoes.export(create) -->
     static TestAPI.Structs_PuttingTypesIntoQuestionablePlaces create(

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_PuttingTypesIntoQuestionablePlaces.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_PuttingTypesIntoQuestionablePlaces.dart
@@ -84,9 +84,6 @@ class Structs_PuttingTypesIntoQuestionablePlaces extends SwiftReference {
         createRef(Structs_PuttingTypesIntoQuestionablePlaces(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.Structs_PuttingTypesIntoQuestionablePlaces()';
-
     /// <!-- FishyJoes.export(create) -->
     static TestAPI.Structs_PuttingTypesIntoQuestionablePlaces create(
     ) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_ReferenceStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_ReferenceStruct.dart
@@ -84,9 +84,6 @@ class Structs_ReferenceStruct extends SwiftReference {
         createRef(Structs_ReferenceStruct(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.Structs_ReferenceStruct(immutable: $immutable, mutable: $mutable)';
-
     /// <!-- FishyJoes.export(immutable) -->
     String get immutable =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_ReferenceStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_ReferenceStruct.dart
@@ -85,7 +85,7 @@ class Structs_ReferenceStruct extends SwiftReference {
     );
 
     @override
-    String toString() => 'Structs_ReferenceStruct(immutable: $immutable, mutable: $mutable, hashCode: $hashCode)';
+    String toString() => 'Structs_ReferenceStruct(immutable: $immutable, mutable: $mutable)';
 
     /// <!-- FishyJoes.export(immutable) -->
     String get immutable =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_ReferenceStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/Structs_ReferenceStruct.dart
@@ -85,7 +85,7 @@ class Structs_ReferenceStruct extends SwiftReference {
     );
 
     @override
-    String toString() => 'Structs_ReferenceStruct(immutable: $immutable, mutable: $mutable)';
+    String toString() => 'TestAPI.Structs_ReferenceStruct(immutable: $immutable, mutable: $mutable)';
 
     /// <!-- FishyJoes.export(immutable) -->
     String get immutable =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestAsyncForeignSideFunctionsStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestAsyncForeignSideFunctionsStruct.dart
@@ -170,7 +170,7 @@ class TestAsyncForeignSideFunctionsStruct implements TestAPI.TestAsyncFunctions 
         ))
     );
     @override
-    String toString() => 'TestAsyncForeignSideFunctionsStruct(const42: $const42, iabs: $iabs, intCompose: $intCompose, add3Things: $add3Things, makeList: $makeList, fifthThing: $fifthThing, six: $six, willThrow: $willThrow, exercise0Fun: $exercise0Fun, exercise1Fun: $exercise1Fun, exercise2Fun: $exercise2Fun, exercise3Fun: $exercise3Fun, exercise4Fun: $exercise4Fun, exercise5Fun: $exercise5Fun, exercise6Fun: $exercise6Fun, thunkTwiceMakerFun: $thunkTwiceMakerFun)';
+    String toString() => 'TestAPI.TestAsyncForeignSideFunctionsStruct(const42: $const42, iabs: $iabs, intCompose: $intCompose, add3Things: $add3Things, makeList: $makeList, fifthThing: $fifthThing, six: $six, willThrow: $willThrow, exercise0Fun: $exercise0Fun, exercise1Fun: $exercise1Fun, exercise2Fun: $exercise2Fun, exercise3Fun: $exercise3Fun, exercise4Fun: $exercise4Fun, exercise5Fun: $exercise5Fun, exercise6Fun: $exercise6Fun, thunkTwiceMakerFun: $thunkTwiceMakerFun)';
 
     static CreatedRef ffi_get_const42(
         UnownedRef obj,

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestAsyncSwiftSideFunctionsClass.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestAsyncSwiftSideFunctionsClass.dart
@@ -85,7 +85,7 @@ class TestAsyncSwiftSideFunctionsClass extends SwiftReference implements TestAPI
     );
 
     @override
-    String toString() => 'TestAsyncSwiftSideFunctionsClass(add3Things: $add3Things, const42: $const42, fifthThing: $fifthThing, iabs: $iabs, intCompose: $intCompose, makeList: $makeList, six: $six, willThrow: $willThrow)';
+    String toString() => 'TestAPI.TestAsyncSwiftSideFunctionsClass(add3Things: $add3Things, const42: $const42, fifthThing: $fifthThing, iabs: $iabs, intCompose: $intCompose, makeList: $makeList, six: $six, willThrow: $willThrow)';
 
     /// <!-- FishyJoes.export(add3Things) -->
     Future<double> Function(double, double, int) get add3Things =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestAsyncSwiftSideFunctionsClass.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestAsyncSwiftSideFunctionsClass.dart
@@ -84,9 +84,6 @@ class TestAsyncSwiftSideFunctionsClass extends SwiftReference implements TestAPI
         createRef(TestAsyncSwiftSideFunctionsClass(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.TestAsyncSwiftSideFunctionsClass(add3Things: $add3Things, const42: $const42, fifthThing: $fifthThing, iabs: $iabs, intCompose: $intCompose, makeList: $makeList, six: $six, willThrow: $willThrow)';
-
     /// <!-- FishyJoes.export(add3Things) -->
     Future<double> Function(double, double, int) get add3Things =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestDefaultComputedPropertiesReference.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestDefaultComputedPropertiesReference.dart
@@ -84,9 +84,6 @@ class TestDefaultComputedPropertiesReference extends SwiftReference implements T
         createRef(TestDefaultComputedPropertiesReference(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.TestDefaultComputedPropertiesReference(noot: $noot, plutonic: $plutonic, spam: $spam)';
-
     /// <!-- FishyJoes.export(noot) -->
     int get noot =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestDefaultComputedPropertiesReference.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestDefaultComputedPropertiesReference.dart
@@ -85,7 +85,7 @@ class TestDefaultComputedPropertiesReference extends SwiftReference implements T
     );
 
     @override
-    String toString() => 'TestDefaultComputedPropertiesReference(noot: $noot, plutonic: $plutonic, spam: $spam)';
+    String toString() => 'TestAPI.TestDefaultComputedPropertiesReference(noot: $noot, plutonic: $plutonic, spam: $spam)';
 
     /// <!-- FishyJoes.export(noot) -->
     int get noot =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestDefaultComputedPropertiesStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestDefaultComputedPropertiesStruct.dart
@@ -100,7 +100,7 @@ class TestDefaultComputedPropertiesStruct implements TestAPI.TestDefaultComputed
         ))
     );
     @override
-    String toString() => 'TestDefaultComputedPropertiesStruct(spam: $spam, noot: $noot)';
+    String toString() => 'TestAPI.TestDefaultComputedPropertiesStruct(spam: $spam, noot: $noot)';
 
     static bool ffi_get_spam(
         UnownedRef obj,

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestDifferingExportNameStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestDifferingExportNameStruct.dart
@@ -95,7 +95,7 @@ class TestDifferingExportNameStruct implements TestAPI.TestDifferingExportNamePr
         ))
     );
     @override
-    String toString() => 'TestDifferingExportNameStruct(tata: $tata)';
+    String toString() => 'TestAPI.TestDifferingExportNameStruct(tata: $tata)';
 
     static int ffi_get_tata(
         UnownedRef obj,

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestLeadingUnderscoredPropStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestLeadingUnderscoredPropStruct.dart
@@ -95,7 +95,7 @@ class TestLeadingUnderscoredPropStruct implements TestAPI.TestLeadingUnderscored
         ))
     );
     @override
-    String toString() => 'TestLeadingUnderscoredPropStruct(m_leadingUnderscoreProp: $m_leadingUnderscoreProp)';
+    String toString() => 'TestAPI.TestLeadingUnderscoredPropStruct(m_leadingUnderscoreProp: $m_leadingUnderscoreProp)';
 
     static CreatedRef ffi_get__leadingUnderscoreProp(
         UnownedRef obj,

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestProtocolClass.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestProtocolClass.dart
@@ -85,7 +85,7 @@ class TestProtocolClass extends SwiftReference implements TestAPI.TestMethodsPro
     );
 
     @override
-    String toString() => 'TestProtocolClass(corge: $corge, flarp: $flarp, frobby: $frobby, hashCode: $hashCode)';
+    String toString() => 'TestProtocolClass(corge: $corge, flarp: $flarp, frobby: $frobby)';
 
     /// <!-- FishyJoes.export(corge) -->
     String get corge =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestProtocolClass.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestProtocolClass.dart
@@ -85,7 +85,7 @@ class TestProtocolClass extends SwiftReference implements TestAPI.TestMethodsPro
     );
 
     @override
-    String toString() => 'TestProtocolClass(corge: $corge, flarp: $flarp, frobby: $frobby)';
+    String toString() => 'TestAPI.TestProtocolClass(corge: $corge, flarp: $flarp, frobby: $frobby)';
 
     /// <!-- FishyJoes.export(corge) -->
     String get corge =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestProtocolClass.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestProtocolClass.dart
@@ -84,9 +84,6 @@ class TestProtocolClass extends SwiftReference implements TestAPI.TestMethodsPro
         createRef(TestProtocolClass(ref))
     );
 
-    @override
-    String toString() => 'TestAPI.TestProtocolClass(corge: $corge, flarp: $flarp, frobby: $frobby)';
-
     /// <!-- FishyJoes.export(corge) -->
     String get corge =>
         GCRef.using(this, (_thisHandle) =>

--- a/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestProtocolStruct.dart
+++ b/integration-tests/TestAPI-bindings/dart/lib/src/generated/TestProtocolStruct.dart
@@ -95,7 +95,7 @@ class TestProtocolStruct implements TestAPI.TestMethodsProtocol, TestAPI.TestPro
         ))
     );
     @override
-    String toString() => 'TestProtocolStruct(corge: $corge)';
+    String toString() => 'TestAPI.TestProtocolStruct(corge: $corge)';
 
     static CreatedRef ffi_get_corge(
         UnownedRef obj,

--- a/integration-tests/TestAPI-bindings/dart/test/attributed_string_test.dart
+++ b/integration-tests/TestAPI-bindings/dart/test/attributed_string_test.dart
@@ -489,10 +489,10 @@ void main() {
           // struct reference 'a' itself is mutable, but struct property x is immutable because it's marked as 'final'
           // compiler will not allow a.x = "something else";
           expect(a.x, equals("quxx"));
-          expect(a.toString(), equals("AttributedString_PuttingTypesIntoQuestionablePlaces(x: quxx)"));
+          expect(a.toString(), equals("TestAPI.AttributedString_PuttingTypesIntoQuestionablePlaces(x: quxx)"));
           a = b;
-          expect(a.toString(), equals("AttributedString_PuttingTypesIntoQuestionablePlaces(x: garply)"));
-          expect(c.toString(), equals("AttributedString_PuttingTypesIntoQuestionablePlaces(x: corgle)"));
+          expect(a.toString(), equals("TestAPI.AttributedString_PuttingTypesIntoQuestionablePlaces(x: garply)"));
+          expect(c.toString(), equals("TestAPI.AttributedString_PuttingTypesIntoQuestionablePlaces(x: corgle)"));
           expect(c != a, true);
           expect(c != b, true);
           expect(a.hashCode, equals(b.hashCode));

--- a/integration-tests/TestAPI-bindings/dart/test/class_test.dart
+++ b/integration-tests/TestAPI-bindings/dart/test/class_test.dart
@@ -11,8 +11,6 @@ void main() {
 
   group('ClassTests', () {
       test('testEmptyClass', () {
-        print('pid: $pid');
-
         final a1 = EmptyClass1.create();
         final a2 = EmptyClass1.create();
         expect(a1.blarg, equals("Blarg!"));

--- a/integration-tests/TestAPI-bindings/dart/test/class_test.dart
+++ b/integration-tests/TestAPI-bindings/dart/test/class_test.dart
@@ -11,6 +11,8 @@ void main() {
 
   group('ClassTests', () {
       test('testEmptyClass', () {
+        print('pid: $pid');
+
         final a1 = EmptyClass1.create();
         final a2 = EmptyClass1.create();
         expect(a1.blarg, equals("Blarg!"));
@@ -32,8 +34,8 @@ void main() {
         expect(a1.hashCode, isNot(equals(b1.hashCode)));
         expect(a1.toString(), isNot(equals(b1.toString())));
 
-        expect(a1.toString(), equals("TestAPI.EmptyClass1(blarg: Blarg!, wibbledyWobbledyTimeyWhimey: <wibble>*Wobble*)"));
-        expect(b1.toString(), equals("TestAPI.EmptyClass2(blorg: Gralb!, wibble: <timey>*Whimey*)"));
+        expect(a1.toString(), equals("TestAPI.EmptyClass"));
+        expect(b1.toString(), equals("TestAPI.EmptyClass2"));
       });
   });
 }

--- a/integration-tests/TestAPI-bindings/dart/test/class_test.dart
+++ b/integration-tests/TestAPI-bindings/dart/test/class_test.dart
@@ -31,6 +31,9 @@ void main() {
         expect(a1, isNot(equals(b1)));
         expect(a1.hashCode, isNot(equals(b1.hashCode)));
         expect(a1.toString(), isNot(equals(b1.toString())));
+
+        expect(a1.toString(), equals("EmptyClass1(blarg: Blarg!, wibbledyWobbledyTimeyWhimey: <wibble>*Wobble*)"));
+        expect(b1.toString(), equals("EmptyClass2(blorg: Gralb!, wibble: <timey>*Whimey*)"));
       });
   });
 }

--- a/integration-tests/TestAPI-bindings/dart/test/class_test.dart
+++ b/integration-tests/TestAPI-bindings/dart/test/class_test.dart
@@ -32,8 +32,8 @@ void main() {
         expect(a1.hashCode, isNot(equals(b1.hashCode)));
         expect(a1.toString(), isNot(equals(b1.toString())));
 
-        expect(a1.toString(), equals("EmptyClass1(blarg: Blarg!, wibbledyWobbledyTimeyWhimey: <wibble>*Wobble*)"));
-        expect(b1.toString(), equals("EmptyClass2(blorg: Gralb!, wibble: <timey>*Whimey*)"));
+        expect(a1.toString(), equals("TestAPI.EmptyClass1(blarg: Blarg!, wibbledyWobbledyTimeyWhimey: <wibble>*Wobble*)"));
+        expect(b1.toString(), equals("TestAPI.EmptyClass2(blorg: Gralb!, wibble: <timey>*Whimey*)"));
       });
   });
 }

--- a/integration-tests/TestAPI-bindings/dart/test/struct_test.dart
+++ b/integration-tests/TestAPI-bindings/dart/test/struct_test.dart
@@ -24,7 +24,7 @@ void main() {
         expect(a1, equals(a2));
         expect(a1.hashCode, equals(a2.hashCode));
         expect(a1.toString(), equals(a2.toString()));
-        expect(a1.toString(), equals("EmptyStruct()"));
+        expect(a1.toString(), equals("TestAPI.EmptyStruct()"));
 
         final b1 = EmptyStruct2.create();
         expect(b1.tutu, equals(12897));

--- a/integration-tests/TestAPI-bindings/kotlin/src/test/kotlin/com/cricut/testapi/AttributedStringTests.kt
+++ b/integration-tests/TestAPI-bindings/kotlin/src/test/kotlin/com/cricut/testapi/AttributedStringTests.kt
@@ -467,4 +467,30 @@ internal class AttributedStringTests {
         assertEquals(runRanges.count(), 1)
         assertEquals(attributedString, AttributedString.create("Hello Olá こんにちは"))
     }
+
+    @Test
+    fun testAttributedStringPuttingTypesIntoQuestionablePlaces() {
+        val a1 = AttributedString_PuttingTypesIntoQuestionablePlaces(x = "quxx")
+        val a2 = AttributedString_PuttingTypesIntoQuestionablePlaces(x = "quxx")
+        val b1 = AttributedString_PuttingTypesIntoQuestionablePlaces(x = "corgle")
+        val b2 = AttributedString_PuttingTypesIntoQuestionablePlaces(x = "garply")
+
+        assertEquals("quxx", a1.x)
+        assertEquals("quxx", a2.x)
+        assertEquals("corgle", b1.x)
+        assertEquals("garply", b2.x)
+
+        assertEquals("AttributedString_PuttingTypesIntoQuestionablePlaces(x=quxx)", a1.toString())
+        assertEquals("AttributedString_PuttingTypesIntoQuestionablePlaces(x=quxx)", a2.toString())
+        assertEquals("AttributedString_PuttingTypesIntoQuestionablePlaces(x=corgle)", b1.toString())
+        assertEquals("AttributedString_PuttingTypesIntoQuestionablePlaces(x=garply)", b2.toString())
+
+        assertEquals(a1.hashCode(), a2.hashCode())
+        assertNotEquals(b1.hashCode(), b2.hashCode())
+
+        assertEquals(42, a1.testCall())
+        assertEquals(42, a2.testCall())
+        assertEquals(42, b1.testCall())
+        assertEquals(42, b2.testCall())
+    }
 }

--- a/integration-tests/TestAPI-bindings/kotlin/src/test/kotlin/com/cricut/testapi/ClassTests.kt
+++ b/integration-tests/TestAPI-bindings/kotlin/src/test/kotlin/com/cricut/testapi/ClassTests.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 
 internal class ClassTests {
     companion object {
-        const val DEBUG_PRINTS = true
+        const val DEBUG_PRINTS = false
         @BeforeAll
         @JvmStatic
         // To get procId for attaching lldb debugger to

--- a/integration-tests/TestAPI-bindings/kotlin/src/test/kotlin/com/cricut/testapi/ClassTests.kt
+++ b/integration-tests/TestAPI-bindings/kotlin/src/test/kotlin/com/cricut/testapi/ClassTests.kt
@@ -2,9 +2,22 @@ package com.cricut.testapi
 
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 
 internal class ClassTests {
+    companion object {
+        const val DEBUG_PRINTS = true
+        @BeforeAll
+        @JvmStatic
+        // To get procId for attaching lldb debugger to
+        fun beforeAll() {
+            val procId = ProcessHandle.current().pid()
+            if (DEBUG_PRINTS) {
+                println("procId: $procId")
+            }
+        }
+    }
     @Test
     fun testEmptyClass() {
         val a1 = EmptyClass1.create()
@@ -26,7 +39,7 @@ internal class ClassTests {
         assertNotEquals(a1, b1)
         assertNotEquals(a1.hashCode(), b1.hashCode())
 
-        assertEquals("TestAPI.EmptyClass1(blarg: Blarg!, wibbledyWobbledyTimeyWhimey: <wibble>*Wobble*)", a1.toString())
-        assertEquals("TestAPI.EmptyClass2(blorg: Gralb!, wibble: <timey>*Whimey*)", b1.toString())
+        assertEquals("TestAPI.EmptyClass", a1.toString())
+        assertEquals("TestAPI.EmptyClass2", b1.toString())
     }
 }

--- a/integration-tests/TestAPI-bindings/kotlin/src/test/kotlin/com/cricut/testapi/ClassTests.kt
+++ b/integration-tests/TestAPI-bindings/kotlin/src/test/kotlin/com/cricut/testapi/ClassTests.kt
@@ -26,7 +26,7 @@ internal class ClassTests {
         assertNotEquals(a1, b1)
         assertNotEquals(a1.hashCode(), b1.hashCode())
 
-        assertEquals("TestAPI.EmptyClass", a1.toString())
-        assertEquals("TestAPI.EmptyClass2", b1.toString())
+        assertEquals("TestAPI.EmptyClass1(blarg: Blarg!, wibbledyWobbledyTimeyWhimey: <wibble>*Wobble*)", a1.toString())
+        assertEquals("TestAPI.EmptyClass2(blorg: Gralb!, wibble: <timey>*Whimey*)", b1.toString())
     }
 }

--- a/integration-tests/TestAPI-bindings/node-test/Classes.test.ts
+++ b/integration-tests/TestAPI-bindings/node-test/Classes.test.ts
@@ -4,24 +4,18 @@ test('EmptyClass', () => {
     //console.log('pid: ' + process.pid);
     let a1 = TestAPI.EmptyClass1.create()
     let a2 = TestAPI.EmptyClass1.create()
+
     expect(a1.blarg).toEqual("Blarg!")
     expect(a1.wibbledyWobbledyTimeyWhimey).toEqual("<wibble>*Wobble*")
     expect(a1.shme()).toEqual("Shme! Hand me my hook.")
     expect(a1.Gorpers()).toEqual("Go Gorp!")
 
-    let testDict = {
-        a1: 'help me',
-        a2: 'o deer'
-    }
+    // There's not a standard equals/hashCode in javascript so we are not implementing it for typescript
+    let testDict: {[key: string]: string} = {};
+    testDict[a1.toString()] = 'gorp'
 
-    console.log("testDict: " + JSON.stringify(testDict));
-    // let c = testDict[a1]
-    // console.log("c " + c);
-
-    let hash1 = a1.hashCode
-    console.log("hash1: " + hash1)
-    let toString = a1.toString()
-    console.log("toString: " + toString)
+    let c = testDict[a1.toString()]
+    expect(c).toEqual("gorp")
 
     expect(a1).toStrictEqual(a2)
 
@@ -30,6 +24,12 @@ test('EmptyClass', () => {
     expect(b1.wibble).toEqual("<timey>*Whimey*")
     expect(b1.shmee()).toEqual("Shme? What's that ticking sound?")
     expect(b1.gorp()).toEqual("Stop Sreprog!")
+
+    testDict[b1.toString()] = 'xyzyx'
+    let d = testDict[b1.toString()]
+    expect(d).toEqual("xyzyx")
+
+    expect(JSON.stringify(testDict)).toEqual('{"TestAPI.EmptyClass":"gorp","TestAPI.EmptyClass2":"xyzyx"}')
 
     expect(a1).not.toStrictEqual(b1)
 });

--- a/integration-tests/TestAPI-bindings/node-test/Classes.test.ts
+++ b/integration-tests/TestAPI-bindings/node-test/Classes.test.ts
@@ -1,8 +1,7 @@
 import { TestAPI } from 'TestAPI';
 
 test('EmptyClass', () => {
-    console.log('pid: ' + process.pid);
-
+    //console.log('pid: ' + process.pid);
     let a1 = TestAPI.EmptyClass1.create()
     let a2 = TestAPI.EmptyClass1.create()
     expect(a1.blarg).toEqual("Blarg!")

--- a/integration-tests/TestAPI-bindings/node-test/Classes.test.ts
+++ b/integration-tests/TestAPI-bindings/node-test/Classes.test.ts
@@ -1,12 +1,28 @@
 import { TestAPI } from 'TestAPI';
 
 test('EmptyClass', () => {
+    console.log('pid: ' + process.pid);
+
     let a1 = TestAPI.EmptyClass1.create()
     let a2 = TestAPI.EmptyClass1.create()
     expect(a1.blarg).toEqual("Blarg!")
     expect(a1.wibbledyWobbledyTimeyWhimey).toEqual("<wibble>*Wobble*")
     expect(a1.shme()).toEqual("Shme! Hand me my hook.")
     expect(a1.Gorpers()).toEqual("Go Gorp!")
+
+    let testDict = {
+        a1: 'help me',
+        a2: 'o deer'
+    }
+
+    console.log("testDict: " + JSON.stringify(testDict));
+    // let c = testDict[a1]
+    // console.log("c " + c);
+
+    let hash1 = a1.hashCode
+    console.log("hash1: " + hash1)
+    let toString = a1.toString()
+    console.log("toString: " + toString)
 
     expect(a1).toStrictEqual(a2)
 


### PR DESCRIPTION
Fix toString for Dart SwiftReferences. Add tests. Add toString to Node objects.

If an export is a SwiftReference, then we should use the runtime's toString method to get the swift objects string description.

I'm not sure if we should generate toString methods on the foreign language side for non reference exports for all languages, but I'm doing it for dart.

The foreign language side built in toString is not symmetric across languages, each language that has it built in will do it differently.