### PR TITLE
Switch to reactor model for wasm

### DIFF
--- a/Sources/FishyJoesExecute/Platform.swift
+++ b/Sources/FishyJoesExecute/Platform.swift
@@ -185,9 +185,7 @@ enum Platform: CustomStringConvertible, Hashable {
             args.append(contentsOf: ["--triple", "wasm32-unknown-wasi"])
             // custom build paths to avoid different versions of spm destroying each other's caches
             args.append(contentsOf: ["--build-path", ".\(ps).build\(ps)wasm-build"])
-
-            // TODO: see https://blog.swiftwasm.org/posts/5-6-released/
-            // args.append(contentsOf: ["-Xswiftc", "-Xclang-linker", "-Xswiftc", "-mexec-model=reactor"])
+            args.append(contentsOf: ["-Xswiftc", "-Xclang-linker", "-Xswiftc", "-mexec-model=reactor"])
 
             env = ["WASM_ONLY": "1"]
         case .node, .kotlinSystem, .dart:

--- a/Sources/FishyJoesNodeRuntime/Templates/wasm-napi.js
+++ b/Sources/FishyJoesNodeRuntime/Templates/wasm-napi.js
@@ -1899,6 +1899,7 @@ export class NAPI {
     this.indirectFunctionTable = instance.exports.__indirect_function_table;
 
     this.wasi.start(instance);
+    instance.exports._initialize?.();
 
     this.errorMessageTable = this.allocateErrorMessages();
     this.extendedErrorInfoPtr = this.malloc(16);


### PR DESCRIPTION
C++ was doing some deinitialization that finally broke the command model