### PR TITLE
Add `extraDynamicLibraries` parameter to fishy-joes.yaml 

### DIFF
--- a/Sources/FishyJoesCore/FishyJoesContext.swift
+++ b/Sources/FishyJoesCore/FishyJoesContext.swift
@@ -60,10 +60,17 @@ public class FishyJoesContext {
         else {
             fatalErr("must provide `requiredModules` as argument to sourcery")
         }
+        guard let extraDynamicLibrariesBase64 = argument["extraDynamicLibraries"] as? String,
+              let extraDynamicLibrariesJSON = Data(base64Encoded: extraDynamicLibrariesBase64),
+              let extraDynamicLibraries = try? JSONDecoder().decode([String].self, from: extraDynamicLibrariesJSON)
+        else {
+            fatalErr("must provide `extraDynamicLibraries` as argument to sourcery")
+        }
         self.templateContext = context
         self.module = Module(
             name: module,
-            dependencies: requiredModulePaths.map { (($0 as NSString).lastPathComponent as NSString).deletingPathExtension }
+            dependencies: requiredModulePaths.map { (($0 as NSString).lastPathComponent as NSString).deletingPathExtension },
+            extraDynamicLibraries: extraDynamicLibraries
         )
         self.requiredModulePaths = requiredModulePaths
         self.tsAnnotations = TypeScriptAnnotations(

--- a/Sources/FishyJoesCore/Module.swift
+++ b/Sources/FishyJoesCore/Module.swift
@@ -15,6 +15,13 @@ struct Module: Hashable, CustomStringConvertible, Codable {
     var cSharpNamespace: String { "Cricut.\(name)" }
     var dartNamespace: String { name }
     var description: String { name }
+    
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.dependencies = try container.decode([String].self, forKey: .dependencies)
+        self.extraDynamicLibraries = try container.decodeIfPresent([String].self, forKey: .extraDynamicLibraries) ?? []
+    }
 }
 
 extension Module {

--- a/Sources/FishyJoesCore/Module.swift
+++ b/Sources/FishyJoesCore/Module.swift
@@ -3,10 +3,12 @@ import Foundation
 struct Module: Hashable, CustomStringConvertible, Codable {
     let name: String
     let dependencies: [String]
+    let extraDynamicLibraries: [String]
 
-    init(name: String, dependencies: [String]) {
+    init(name: String, dependencies: [String], extraDynamicLibraries: [String] = []) {
         self.name = name
         self.dependencies = dependencies.sorted()
+        self.extraDynamicLibraries = extraDynamicLibraries
     }
 
     var kotlinPackage: String { "com.cricut.\(name.lowercased())" }
@@ -27,7 +29,8 @@ extension Module {
     static var runtime: Module {
         Module(
             name: "FishyJoesRuntime",
-            dependencies: []
+            dependencies: [],
+            extraDynamicLibraries: []
         )
     }
 }

--- a/Sources/FishyJoesCore/Module.swift
+++ b/Sources/FishyJoesCore/Module.swift
@@ -15,7 +15,7 @@ struct Module: Hashable, CustomStringConvertible, Codable {
     var cSharpNamespace: String { "Cricut.\(name)" }
     var dartNamespace: String { name }
     var description: String { name }
-    
+
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.name = try container.decode(String.self, forKey: .name)

--- a/Sources/FishyJoesCore/Translators/KotlinTranslator.swift
+++ b/Sources/FishyJoesCore/Translators/KotlinTranslator.swift
@@ -395,7 +395,13 @@ final class KotlinTranslator: Translator {
         ktFragment.blankLine()
         ktFragment.outputBlock("public object \(repName): LibraryLoader.LibraryRepresentative {") {
             ktFragment.output("override fun ensureLoaded() {}")
-            ktFragment.output("override val nativeLibs = listOf(\"\(module.name)\", \"\(module.name)-java\")")
+
+            var nativeLibs = [String]()
+            nativeLibs.append(contentsOf: module.extraDynamicLibraries)
+            nativeLibs.append(contentsOf: [module.name, "\(module.name)-java"])
+            let listOfStr = nativeLibs.map { "\"\($0)\"" }.joined(separator: ", ")
+
+            ktFragment.output("override val nativeLibs = listOf(\(listOfStr))")
             let deps = ["FishyJoesRuntimeRepresentative"] + module.dependencies.map { "\($0)LoaderRepresentative" }
             ktFragment.outputBlock("override val dependencies: List<LibraryLoader.LibraryRepresentative> = listOf(") {
                 ktFragment.outputMap(deps, separator: ",", { $0 })

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -495,6 +495,9 @@ extension CodeGen {
                         }
                     }
                     if platform == .node {
+                        try config.extraDynamicLibraries.forEach {
+                            try installLibrary($0)
+                        }
                         // Install the module library and Node interfacing library
                         try installLibrary(nodeModule.name)
                         try installLibrary(nodeModule.nativeLibName)

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -221,6 +221,8 @@ extension CodeGen {
             let errorReporter = cmd("cat", errorFifoPath).async(stdout: .stderr)
 
             // Execute Sourcery to generate the Swift-side and foreign-side source files for all supported language targets
+            let base64RequiredModules = try! JSONEncoder().encode(fishyJoesModuleFiles).base64EncodedString()
+            let base64ExtraDynamicLibraries = try! JSONEncoder().encode(config.extraDynamicLibraries).base64EncodedString()
             try cmd(
                 ".build\(ps)debug\(ps)sourcery",
                 arguments: [
@@ -231,7 +233,8 @@ extension CodeGen {
                     "--templates", ".build\(ps)debug\(ps)FishyJoes_FishyJoesExecutionHelper.bundle\(ps)FishyJoes.swifttemplate",
                     "--args", "module=\(config.module)",
                     "--args", "debugRepresentation=\(dumpDebugRepresentation)",
-                    "--args", "requiredModules=\"\(try! JSONEncoder().encode(fishyJoesModuleFiles).base64EncodedString())\"",
+                    "--args", "requiredModules=\"\(base64RequiredModules)\"",
+                    "--args", "extraDynamicLibraries=\"\(base64ExtraDynamicLibraries)\"",
                     "--args", "fishyJoesExecutable=.build\(ps)debug\(ps)helper-fishy-joes-core",
                     "--args", "stderrFifo=\(errorFifoPath)",
                     "--output", "Sources\(ps)Generated"

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -290,7 +290,7 @@ extension CodeGen {
 
             // Build libraries for the requested platforms
             for platform in platforms {
-                let libs = [config.module] + config.requiredModules
+                let libs = [config.module] + config.requiredModules + config.extraDynamicLibraries
                 switch platform {
                 case .wasm:
                     try platform.build(configuration: configuration)

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -293,26 +293,29 @@ extension CodeGen {
 
             // Build libraries for the requested platforms
             for platform in platforms {
-                let libs = [config.module] + config.requiredModules + config.extraDynamicLibraries
+                let libs = [config.module] + config.requiredModules
                 switch platform {
                 case .wasm:
                     try platform.build(configuration: configuration)
                 case .node:
+                    let nodeLibsToBuild = config.extraDynamicLibraries + libs.flatMap { [$0, "\($0)-node"] } + ["FishyJoesNodeRuntime"]
                     try platform.build(
                         product: "\(config.module)-node",
-                        libs: libs.flatMap { [$0, "\($0)-node"] } + ["FishyJoesNodeRuntime"],
+                        libs: nodeLibsToBuild,
                         configuration: configuration
                     )
                 case .kotlinSystem, .kotlinAndroid:
+                    let javaLibsToBuild = config.extraDynamicLibraries + libs.flatMap { [$0, "\($0)-java"] } + ["FishyJoesJavaRuntime"]
                     try platform.build(
                         product: "\(config.module)-java",
-                        libs: libs.flatMap { [$0, "\($0)-java"] } + ["FishyJoesJavaRuntime"],
+                        libs: javaLibsToBuild,
                         configuration: configuration
                     )
                 case .cSharp, .dart:
+                    let iotaLibsToBuild = config.extraDynamicLibraries + libs.flatMap { [$0, "\($0)-iota"] } + ["FishyJoesIotaRuntime"]
                     try platform.build(
                         product: "\(config.module)-iota",
-                        libs: libs.flatMap { [$0, "\($0)-iota"] } + ["FishyJoesIotaRuntime"],
+                        libs: iotaLibsToBuild,
                         configuration: configuration
                     )
                 }

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -298,7 +298,7 @@ extension CodeGen {
                 case .wasm:
                     try platform.build(configuration: configuration)
                 case .node:
-                    let nodeLibsToBuild = libs.flatMap { [$0, "\($0)-node"] } + ["FishyJoesNodeRuntime"]
+                    let nodeLibsToBuild = config.extraDynamicLibraries + libs.flatMap { [$0, "\($0)-node"] } + ["FishyJoesNodeRuntime"]
                     try platform.build(
                         product: "\(config.module)-node",
                         libs: nodeLibsToBuild,

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -298,7 +298,7 @@ extension CodeGen {
                 case .wasm:
                     try platform.build(configuration: configuration)
                 case .node:
-                    let nodeLibsToBuild = config.extraDynamicLibraries + libs.flatMap { [$0, "\($0)-node"] } + ["FishyJoesNodeRuntime"]
+                    let nodeLibsToBuild = libs.flatMap { [$0, "\($0)-node"] } + ["FishyJoesNodeRuntime"]
                     try platform.build(
                         product: "\(config.module)-node",
                         libs: nodeLibsToBuild,

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -682,12 +682,16 @@ extension CodeGen {
                         .run()
                 case .kotlinSystem, .kotlinAndroid:
                     // Install the module library and interfacing JNI library
+                    try config.extraDynamicLibraries.forEach {
+                        try installLibrary($0)
+                    }
                     try installLibrary(config.module)
                     try installLibrary("\(config.module)-java")
                 case .cSharp:
                     // Install the module library, interfacing library, and required module libraries
                     try cmd("mkdir", "-p", outputDir).run()
-                    let libs = [
+                    var libs = config.extraDynamicLibraries
+                    libs += [
                         "FishyJoesIotaRuntime",
                         config.module,
                         config.module + "-iota",
@@ -703,7 +707,8 @@ extension CodeGen {
                 case .dart:
                     // Install the module library, interfacing library, and required module libraries, signing if necessary
                     try cmd("mkdir", "-p", outputDir).run()
-                    let libs = [
+                    var libs = config.extraDynamicLibraries
+                    libs += [
                         "FishyJoesIotaRuntime",
                         config.module,
                         config.module + "-iota",

--- a/Sources/FishyJoesExecute/FishyJoesConfig.swift
+++ b/Sources/FishyJoesExecute/FishyJoesConfig.swift
@@ -6,6 +6,7 @@ struct FishyJoesConfig: Codable {
     let module: String
     let publishRepository: String?
     let requiredModules: [String]
+    let extraDynamicLibraries: [String]
     let excludeSources: [String]
 
     static func readFromFile() throws -> FishyJoesConfig {
@@ -43,12 +44,18 @@ struct FishyJoesConfig: Codable {
             }
             return list
         }
+        let extraDynamicLibraries = try configDictionary["extraDynamicLibraries"].map { obj -> [String] in
+            guard let list = obj as? [String] else {
+                throw ValidationError("fishy-joes.yaml value for key `extraDynamicLibraries` is not an array of file or directory paths")
+            }
+            return list
+        }
         let excludeSources = try configDictionary["excludeSources"].map { obj -> [String] in
             guard let list = obj as? [String] else {
                 throw ValidationError("fishy-joes.yaml value for key `excludeSources` is not an array of file or directory paths")
             }
             return list
         }
-        return FishyJoesConfig(module: module, publishRepository: publishRepository, requiredModules: requiredModules ?? [], excludeSources: excludeSources ?? [])
+        return FishyJoesConfig(module: module, publishRepository: publishRepository, requiredModules: requiredModules ?? [], extraDynamicLibraries: extraDynamicLibraries ?? [], excludeSources: excludeSources ?? [])
     }
 }

--- a/Sources/FishyJoesExecute/FishyJoesConfig.swift
+++ b/Sources/FishyJoesExecute/FishyJoesConfig.swift
@@ -46,7 +46,7 @@ struct FishyJoesConfig: Codable {
         }
         let extraDynamicLibraries = try configDictionary["extraDynamicLibraries"].map { obj -> [String] in
             guard let list = obj as? [String] else {
-                throw ValidationError("fishy-joes.yaml value for key `extraDynamicLibraries` is not an array of file or directory paths")
+                throw ValidationError("fishy-joes.yaml value for key `extraDynamicLibraries` is not an array of file names")
             }
             return list
         }

--- a/Sources/FishyJoesExecute/PackageInit.swift
+++ b/Sources/FishyJoesExecute/PackageInit.swift
@@ -189,7 +189,7 @@ public struct PackageInit: ParsableCommand {
         let config = FishyJoesConfig(
             module: module,
             publishRepository: publishRepository,
-            requiredModules: requiredModules.split(separator: " ").map(String.init), 
+            requiredModules: requiredModules.split(separator: " ").map(String.init),
             extraDynamicLibraries: extraDynamicLibraries.split(separator: " ").map(String.init),
             excludeSources: excludeSources.split(separator: " ").map(String.init)
         )

--- a/Sources/FishyJoesExecute/PackageInit.swift
+++ b/Sources/FishyJoesExecute/PackageInit.swift
@@ -176,6 +176,11 @@ public struct PackageInit: ParsableCommand {
             allowEmpty: true
         )
 
+        let extraDynamicLibraries = try Interactive.prompt(
+            "Dynamic libraries that do not have a -bindings repo and so are not in the requiredModules of \(module), space separated. Default []: ",
+            allowEmpty: true
+        )
+
         let excludeSources = try Interactive.prompt(
             "File or directory paths to exclude from generation, space separated. Default []:",
             allowEmpty: true
@@ -184,7 +189,8 @@ public struct PackageInit: ParsableCommand {
         let config = FishyJoesConfig(
             module: module,
             publishRepository: publishRepository,
-            requiredModules: requiredModules.split(separator: " ").map(String.init),
+            requiredModules: requiredModules.split(separator: " ").map(String.init), 
+            extraDynamicLibraries: extraDynamicLibraries.split(separator: " ").map(String.init),
             excludeSources: excludeSources.split(separator: " ").map(String.init)
         )
 

--- a/Tests/NAPITests/NAPITests.swift
+++ b/Tests/NAPITests/NAPITests.swift
@@ -32,9 +32,14 @@ class NAPITests: XCTestCase {
         "\(testDirectory)/entry_point.c",
     ]
 
-    override func setUp() {
+    override func setUpWithError() throws {
         super.setUp()
         ExternalCommand.verbose = false
+        guard FileManager.default.fileExists(atPath: "Package.swift") else {
+            XCTFail("These tests expect to run in the root of the FishyJoes package. Use `swift test`.")
+            struct BadWorkingDirectory: Error {}
+            throw BadWorkingDirectory()
+        }
     }
 
     func testNative(_ testName: String, js: [String] = ["test.js"], fixups: [String] = []) throws {

--- a/integration-tests/TestAPI-bindings/Sources/Generated/TestAPI.fishyjoesmodule
+++ b/integration-tests/TestAPI-bindings/Sources/Generated/TestAPI.fishyjoesmodule
@@ -28,6 +28,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -78,6 +81,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -132,6 +138,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : false,
@@ -182,6 +191,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -236,6 +248,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -286,6 +301,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -340,6 +358,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : false,
@@ -390,6 +411,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -444,6 +468,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : false,
@@ -494,6 +521,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -548,6 +578,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -598,6 +631,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -652,6 +688,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : false,
@@ -702,6 +741,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -756,6 +798,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -806,6 +851,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -860,6 +908,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -910,6 +961,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -964,6 +1018,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -1014,6 +1071,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -1068,6 +1128,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -1118,6 +1181,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -1172,6 +1238,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -1222,6 +1291,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -1276,6 +1348,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : false,
@@ -1326,6 +1401,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -1380,6 +1458,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -1430,6 +1511,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -1484,6 +1568,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : false,
@@ -1534,6 +1621,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -1588,6 +1678,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -1638,6 +1731,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -1692,6 +1788,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -1742,6 +1841,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -1796,6 +1898,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -1846,6 +1951,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -1900,6 +2008,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -1950,6 +2061,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -2004,6 +2118,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -2054,6 +2171,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -2108,6 +2228,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -2158,6 +2281,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -2212,6 +2338,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -2262,6 +2391,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -2316,6 +2448,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -2366,6 +2501,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -2420,6 +2558,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -2470,6 +2611,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -2524,6 +2668,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -2574,6 +2721,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -2628,6 +2778,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -2678,6 +2831,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -2732,6 +2888,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : true,
@@ -2782,6 +2941,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"
@@ -2836,6 +2998,9 @@
         "dependencies" : [
 
         ],
+        "extraDynamicLibraries" : [
+
+        ],
         "name" : "TestAPI"
       },
       "isInhabited" : false,
@@ -2886,6 +3051,9 @@
       },
       "definingModule" : {
         "dependencies" : [
+
+        ],
+        "extraDynamicLibraries" : [
 
         ],
         "name" : "TestAPI"


### PR DESCRIPTION
This is to support CanvasModel-Swift being depended upon by both CriSVG-bindings and CriCanvas-bindings now.

So we must change from CanvasModel-Swift being linked statically into both -bindings repos, which results in duplicate symbols warnings/errors, to it being linked dynamically. Since CanvasModel-Swift is not a -bindings repo, it needs a separate input argument in fishy-joes.yaml