### PR TITLE
Update kotlin POM maven publish

### DIFF
--- a/Sources/FishyJoesExecute/Resources/bindings-template/kotlin/generated/build.gradle.kts
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/kotlin/generated/build.gradle.kts
@@ -62,6 +62,11 @@ publishing {
 
             from(components["java"])
             artifact(sourcesJar.get())
+
+            pom {
+                name.set("__MODULE_NAME__")
+                url.set("https://__BINDINGS_REPO__")
+            }
         }
     }
 }

--- a/integration-tests/TestAPI/bindings/kotlin/generated/build.gradle.kts
+++ b/integration-tests/TestAPI/bindings/kotlin/generated/build.gradle.kts
@@ -62,6 +62,11 @@ publishing {
 
             from(components["java"])
             artifact(sourcesJar.get())
+
+            pom {
+                name.set("TestAPI")
+                url.set("https://__BINDINGS_REPO__")
+            }
         }
     }
 }


### PR DESCRIPTION
Upstreamed from and closes https://github.com/cricut/CriText/pull/175

> Android repositories are using Renovate tool for automatic dependencies updates.
> Added publication of release notes that can be visualised in Cri-libraries updates PRs.