### PR TITLE
FishyJoes tweaks for issues people are having

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@
 import Foundation
 import PackageDescription
 
-let strictConcurrencyFlags: [SwiftSetting] = [SwiftSetting.enableExperimentalFeature("StrictConcurrency"), .enableUpcomingFeature("InferSendableFromCaptures")]
+let strictConcurrencyFlags: [SwiftSetting] = []
+// [.enableExperimentalFeature("StrictConcurrency"), .enableUpcomingFeature("InferSendableFromCaptures")]
 
 let env = ProcessInfo.processInfo.environment
 let disableGeneration = env["DISABLE_GENERATION"] == "1"

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -275,7 +275,8 @@ extension CodeGen {
             fragment.output(#"import Foundation"#)
             fragment.blankLine()
 
-            fragment.output(#"let strictConcurrencyFlags: [SwiftSetting] = [SwiftSetting.enableExperimentalFeature("StrictConcurrency"), .enableUpcomingFeature("InferSendableFromCaptures")]"#)
+            fragment.output(#"let strictConcurrencyFlags: [SwiftSetting] = []"#)
+            fragment.output(#"// [.enableExperimentalFeature("StrictConcurrency"), .enableUpcomingFeature("InferSendableFromCaptures")]"#)
             fragment.blankLine()
 
             fragment.output(#"let env = ProcessInfo.processInfo.environment"#)

--- a/Sources/FishyJoesExecute/PackageInit.swift
+++ b/Sources/FishyJoesExecute/PackageInit.swift
@@ -157,9 +157,12 @@ public struct PackageInit: ParsableCommand {
         ] + config.requiredModules.map {
             (swift: $0, groupId: "com.cricut.\($0)", artifactId: $0.lowercased())
         }
-        let gradleDependencyLines = gradleDependencies.map {
-            let version = swiftPackage?.dependencyMap[$0.swift]?.versionInGradleFormat ?? "local"
-            return "api(\"\($0.groupId):\($0.artifactId):\(version)\")"
+        let gradleDependencyLines = gradleDependencies.map { dependency in
+            let resolved = swiftPackageResolved?.state(for: dependency.swift)
+            var version = resolved?.version ?? resolved?.branch ?? resolved?.revision ?? "local"
+            // Convert anything like "user/branch" into things gradle can parse, even if it probably won't find a release by that name
+            version = version.replacingOccurrences(of: "/", with: "-")
+            return "api(\"\(dependency.groupId):\(dependency.artifactId):\(version)\")"
         }
         replacements["__GRADLE_DEPENDENCIES__"] = join(lines: gradleDependencyLines, indent: 4)
 

--- a/Sources/FishyJoesExecute/PackageInit.swift
+++ b/Sources/FishyJoesExecute/PackageInit.swift
@@ -158,6 +158,11 @@ public struct PackageInit: ParsableCommand {
             (swift: $0, groupId: "com.cricut.\($0)", artifactId: $0.lowercased())
         }
         let gradleDependencyLines = gradleDependencies.map { dependency in
+            // TODO: figure out how to use gradle version ranges. The solver may not be good enough for this to work properly.
+            // See for example: https://github.com/gradle/gradle/issues/8126
+
+            // let version = swiftPackage?.dependencyMap[$0.swift]?.versionInGradleFormat ?? "local"
+
             let resolved = swiftPackageResolved?.state(for: dependency.swift)
             var version = resolved?.version ?? resolved?.branch ?? resolved?.revision ?? "local"
             // Convert anything like "user/branch" into things gradle can parse, even if it probably won't find a release by that name

--- a/Sources/FishyJoesExecute/Phases/NodePhases.swift
+++ b/Sources/FishyJoesExecute/Phases/NodePhases.swift
@@ -280,8 +280,15 @@ class NodePhases: BasePhases, Phases {
         // Generate the package.json file
         let packageVersion = options.version ?? "0.0.1" // If no version is provided, use a dummy version to build the package
         var npmDependencies: [String: String] = [:]
-        for dependency in nodeDependencies {
-            npmDependencies["@cricut/\(dependency.npmPackageName)"] = dependency.npmModuleVersion
+        if platform == .node {
+            for dependency in nodeDependencies {
+                npmDependencies["@cricut/\(dependency.npmPackageName)"] = dependency.npmModuleVersion
+            }
+        } else if platform == .wasm {
+            npmDependencies["@wasmer/wasi"] = "^0.12.0"
+            npmDependencies["@wasmer/wasmfs"] = "^0.12.0"
+        } else {
+            preconditionFailure("unexpected platform \(platform)")
         }
         var package = NPMPackage(
             config: options.config,

--- a/Sources/FishyJoesExecute/SwiftPackage.swift
+++ b/Sources/FishyJoesExecute/SwiftPackage.swift
@@ -103,29 +103,32 @@ extension SwiftPackage.Dependency {
         return url.scheme == "file" || url.scheme == nil ? url.path : ".build/checkouts/\(url.lastPathComponent)"
     }
 
-    var versionInGradleFormat: String {
-        // https://docs.gradle.org/current/userguide/single_versions.html
-        let spec: String
-        switch self {
-        case .sourceControl(_, _, .branch(let name)):
-            spec = name
-        case .sourceControl(_, _, .revision(let name)):
-            spec = name
-        case .sourceControl(_, _, .upToNextMajor(let baseVersion)):
-            spec = "[\(baseVersion),\(baseVersion.nextMajor))"
-        case .sourceControl(_, _, .upToNextMinor(let baseVersion)):
-            spec = "[\(baseVersion),\(baseVersion.nextMinor))"
-        case .sourceControl(_, _, .range(let lowerBound, let upperBound)):
-            spec = "[\(lowerBound),\(upperBound))"
-        case .sourceControl(_, _, .exact(let version)):
-            spec = version.versionString
-        case .fileSystem:
-            spec = "local"
-        }
+    // Currently unused, kotlin is pinned to an exact version
+    // TODO: figure out how to use gradle version ranges. The solver may not be good enough for this to work properly.
+    // See for example: https://github.com/gradle/gradle/issues/8126
+    // var versionInGradleFormat: String {
+    //     // https://docs.gradle.org/current/userguide/single_versions.html
+    //     let spec: String
+    //     switch self {
+    //     case .sourceControl(_, _, .branch(let name)):
+    //         spec = name
+    //     case .sourceControl(_, _, .revision(let name)):
+    //         spec = name
+    //     case .sourceControl(_, _, .upToNextMajor(let baseVersion)):
+    //         spec = "[\(baseVersion),\(baseVersion.nextMajor))"
+    //     case .sourceControl(_, _, .upToNextMinor(let baseVersion)):
+    //         spec = "[\(baseVersion),\(baseVersion.nextMinor))"
+    //     case .sourceControl(_, _, .range(let lowerBound, let upperBound)):
+    //         spec = "[\(lowerBound),\(upperBound))"
+    //     case .sourceControl(_, _, .exact(let version)):
+    //         spec = version.versionString
+    //     case .fileSystem:
+    //         spec = "local"
+    //     }
 
-        // Convert anything like "user/branch" into things gradle can parse, even if it probably won't find a release by that name
-        return spec.replacingOccurrences(of: "/", with: "-")
-    }
+    //     // Convert anything like "user/branch" into things gradle can parse, even if it probably won't find a release by that name
+    //     return spec.replacingOccurrences(of: "/", with: "-")
+    // }
 
     var versionInNugetFormat: String? {
         // https://learn.microsoft.com/en-us/nuget/concepts/package-versioning

--- a/Sources/FishyJoesExecute/SwiftPackage.swift
+++ b/Sources/FishyJoesExecute/SwiftPackage.swift
@@ -103,32 +103,29 @@ extension SwiftPackage.Dependency {
         return url.scheme == "file" || url.scheme == nil ? url.path : ".build/checkouts/\(url.lastPathComponent)"
     }
 
-    // Currently unused, kotlin is pinned to an exact version
-    // TODO: figure out how to use gradle version ranges. The solver may not be good enough for this to work properly.
-    // See for example: https://github.com/gradle/gradle/issues/8126
-    // var versionInGradleFormat: String {
-    //     // https://docs.gradle.org/current/userguide/single_versions.html
-    //     let spec: String
-    //     switch self {
-    //     case .sourceControl(_, _, .branch(let name)):
-    //         spec = name
-    //     case .sourceControl(_, _, .revision(let name)):
-    //         spec = name
-    //     case .sourceControl(_, _, .upToNextMajor(let baseVersion)):
-    //         spec = "[\(baseVersion),\(baseVersion.nextMajor))"
-    //     case .sourceControl(_, _, .upToNextMinor(let baseVersion)):
-    //         spec = "[\(baseVersion),\(baseVersion.nextMinor))"
-    //     case .sourceControl(_, _, .range(let lowerBound, let upperBound)):
-    //         spec = "[\(lowerBound),\(upperBound))"
-    //     case .sourceControl(_, _, .exact(let version)):
-    //         spec = version.versionString
-    //     case .fileSystem:
-    //         spec = "local"
-    //     }
+    var versionInGradleFormat: String {
+        // https://docs.gradle.org/current/userguide/single_versions.html
+        let spec: String
+        switch self {
+        case .sourceControl(_, _, .branch(let name)):
+            spec = name
+        case .sourceControl(_, _, .revision(let name)):
+            spec = name
+        case .sourceControl(_, _, .upToNextMajor(let baseVersion)):
+            spec = "[\(baseVersion),\(baseVersion.nextMajor))"
+        case .sourceControl(_, _, .upToNextMinor(let baseVersion)):
+            spec = "[\(baseVersion),\(baseVersion.nextMinor))"
+        case .sourceControl(_, _, .range(let lowerBound, let upperBound)):
+            spec = "[\(lowerBound),\(upperBound))"
+        case .sourceControl(_, _, .exact(let version)):
+            spec = version.versionString
+        case .fileSystem:
+            spec = "local"
+        }
 
-    //     // Convert anything like "user/branch" into things gradle can parse, even if it probably won't find a release by that name
-    //     return spec.replacingOccurrences(of: "/", with: "-")
-    // }
+        // Convert anything like "user/branch" into things gradle can parse, even if it probably won't find a release by that name
+        return spec.replacingOccurrences(of: "/", with: "-")
+    }
 
     var versionInNugetFormat: String? {
         // https://learn.microsoft.com/en-us/nuget/concepts/package-versioning

--- a/integration-tests/TestAPI/bindings/swift-interfaces/generated/TestAPI-bindings/Package.swift
+++ b/integration-tests/TestAPI/bindings/swift-interfaces/generated/TestAPI-bindings/Package.swift
@@ -4,7 +4,8 @@
 import PackageDescription
 import Foundation
 
-let strictConcurrencyFlags: [SwiftSetting] = [SwiftSetting.enableExperimentalFeature("StrictConcurrency"), .enableUpcomingFeature("InferSendableFromCaptures")]
+let strictConcurrencyFlags: [SwiftSetting] = []
+// [.enableExperimentalFeature("StrictConcurrency"), .enableUpcomingFeature("InferSendableFromCaptures")]
 
 let env = ProcessInfo.processInfo.environment
 let wasmCompatibleOnly = env["WASM_ONLY"] == "1"

--- a/node-runtime/fishyjoes-runtime-native-macos/package.json
+++ b/node-runtime/fishyjoes-runtime-native-macos/package.json
@@ -13,6 +13,5 @@
   "types" : "Runtime.d.ts",
   "type" : "module",
   "dependencies" : {
-    "buffer" : "^5.7.1"
   }
 }

--- a/node-runtime/fishyjoes-runtime-native-ubuntu/package.json
+++ b/node-runtime/fishyjoes-runtime-native-ubuntu/package.json
@@ -13,6 +13,5 @@
   "types" : "Runtime.d.ts",
   "type" : "module",
   "dependencies" : {
-    "buffer" : "^5.7.1"
   }
 }

--- a/node-runtime/fishyjoes-runtime-native-windows/package.json
+++ b/node-runtime/fishyjoes-runtime-native-windows/package.json
@@ -13,6 +13,5 @@
   "types" : "Runtime.d.ts",
   "type" : "module",
   "dependencies" : {
-    "buffer" : "^5.7.1"
   }
 }

--- a/node-runtime/fishyjoes-runtime-wasm/package.json
+++ b/node-runtime/fishyjoes-runtime-wasm/package.json
@@ -13,6 +13,5 @@
   "types" : "Runtime.d.ts",
   "type" : "module",
   "dependencies" : {
-    "buffer" : "^5.7.1"
   }
 }


### PR DESCRIPTION
Make npm dependencies more accurate

Disable concurrency warning until we are ready to address them

Disable kotlin version ranges :( hopefully temporarily