### PR TITLE
put dart pack-phase tarballs in a more organized place

### DIFF
--- a/Sources/FishyJoesExecute/Phases/DartPhases.swift
+++ b/Sources/FishyJoesExecute/Phases/DartPhases.swift
@@ -114,7 +114,7 @@ class DartPhases: IotaPhases, Phases {
         }
 
         let packageDirectory = "bindings/dart/generated/packages"
-        try cmd("mkdir", "-p", packageDirectory)
+        try cmd("mkdir", "-p", packageDirectory).run()
         try cmd(
             "tar",
             arguments: [

--- a/Sources/FishyJoesExecute/Phases/DartPhases.swift
+++ b/Sources/FishyJoesExecute/Phases/DartPhases.swift
@@ -113,10 +113,12 @@ class DartPhases: IotaPhases, Phases {
             FileManager.default.fileExists(atPath: "\(tarBaseDirectory)/\($0)")
         }
 
+        let packageDirectory = "bindings/dart/generated/packages"
+        try cmd("mkdir", "-p", packageDirectory)
         try cmd(
             "tar",
             arguments: [
-                "-cvzf", "\(options.config.module)-dart-binaries.tgz",
+                "-cvzf", "\(packageDirectory)/\(options.config.module)-dart-binaries.tgz",
                 "-C", tarBaseDirectory,
             ] + binariesToPack
         ).run()

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
@@ -286,7 +286,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: __MODULE_NAME__-dart-binaries.tgz
-          path: __MODULE_NAME__-dart-binaries.tgz
+          path: bindings/dart/generated/packages/__MODULE_NAME__-dart-binaries.tgz
 
       - name: Publish
         shell: zsh {0}
@@ -307,15 +307,17 @@ jobs:
               -q .id
           )
 
-          file=__MODULE_NAME__-dart-binaries.tgz
+          tarballName=__MODULE_NAME__-dart-binaries.tgz
+          tarballPath=bindings/dart/generated/packages/$tarballName
 
+          # Publish pure-dart tarball as a release artifact
           # https://docs.github.com/en/rest/releases/assets#upload-a-release-asset
           curl -f -u "$GITHUB_USER:$GITHUB_PUBLISH_TOKEN" \
             -X POST \
             -H 'Content-Type: application/gzip' \
             -H 'Accept: application/vnd.github.v3+json' \
-            "https://uploads.github.com/repos/$OWNER/$REPO/releases/$releaseID/assets?name=$file" \
-            --data-binary @$file
+            "https://uploads.github.com/repos/$OWNER/$REPO/releases/$releaseID/assets?name=$tarballName" \
+            --data-binary @$tarballPath
 
           # publish flutter NPM package
           npm publish bindings/packed-npm-packages/cricut-flutter-*.tgz

--- a/documentation/bindings-structure.txt
+++ b/documentation/bindings-structure.txt
@@ -25,7 +25,7 @@ CriGeo/bindings/
 │       └── PathTest.kt
 ├── ts/
 │   ├── package.override.json
-│   ├── generated/packages/
+│   ├── generated/packages/    // Not committed
 │   │   ├── node-native-macos/
 │   │   └── wasm/
 │   └── tests/
@@ -73,7 +73,8 @@ CriGeo/bindings/
 │   │   │   └── pubspec.yaml
 │   │   ├── linux/CMakeLists.txt
 │   │   ├── macos/cricut_crigeo.podspec
-│   │   └── windows/CMakeLists.txt
+│   │   ├── windows/CMakeLists.txt
+│   │   └── packages/    // Not committed
 │   └── test/
 │       └── example_test.dart
 └── workflows/

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
@@ -289,7 +289,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: TestAPI-dart-binaries.tgz
-          path: TestAPI-dart-binaries.tgz
+          path: bindings/dart/generated/packages/TestAPI-dart-binaries.tgz
 
       - name: Publish
         shell: zsh {0}

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
@@ -310,15 +310,17 @@ jobs:
               -q .id
           )
 
-          file=TestAPI-dart-binaries.tgz
+          tarballName=TestAPI-dart-binaries.tgz
+          tarballPath=bindings/dart/generated/packages/$tarballName
 
+          # Publish pure-dart tarball as a release artifact
           # https://docs.github.com/en/rest/releases/assets#upload-a-release-asset
           curl -f -u "$GITHUB_USER:$GITHUB_PUBLISH_TOKEN" \
             -X POST \
             -H 'Content-Type: application/gzip' \
             -H 'Accept: application/vnd.github.v3+json' \
-            "https://uploads.github.com/repos/$OWNER/$REPO/releases/$releaseID/assets?name=$file" \
-            --data-binary @$file
+            "https://uploads.github.com/repos/$OWNER/$REPO/releases/$releaseID/assets?name=$tarballName" \
+            --data-binary @$tarballPath
 
           # publish flutter NPM package
           npm publish bindings/packed-npm-packages/cricut-flutter-*.tgz

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-dart.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-dart.yaml
@@ -289,7 +289,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: TestAPI-dart-binaries.tgz
-          path: TestAPI-dart-binaries.tgz
+          path: bindings/dart/generated/packages/TestAPI-dart-binaries.tgz
 
       - name: Publish
         shell: zsh {0}
@@ -310,15 +310,17 @@ jobs:
               -q .id
           )
 
-          file=TestAPI-dart-binaries.tgz
+          tarballName=TestAPI-dart-binaries.tgz
+          tarballPath=bindings/dart/generated/packages/$tarballName
 
+          # Publish pure-dart tarball as a release artifact
           # https://docs.github.com/en/rest/releases/assets#upload-a-release-asset
           curl -f -u "$GITHUB_USER:$GITHUB_PUBLISH_TOKEN" \
             -X POST \
             -H 'Content-Type: application/gzip' \
             -H 'Accept: application/vnd.github.v3+json' \
-            "https://uploads.github.com/repos/$OWNER/$REPO/releases/$releaseID/assets?name=$file" \
-            --data-binary @$file
+            "https://uploads.github.com/repos/$OWNER/$REPO/releases/$releaseID/assets?name=$tarballName" \
+            --data-binary @$tarballPath
 
           # publish flutter NPM package
           npm publish bindings/packed-npm-packages/cricut-flutter-*.tgz


### PR DESCRIPTION
Works because this release has a dart tarball attached to it: https://github.com/cricut/CriGeo/releases/tag/2.12.11-alpha1