### PR TITLE
add optional config for generating workflow files

### DIFF
--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -476,15 +476,18 @@ extension CodeGen {
                 includeFilesNotMarkedAsGenerated: false
             )
             try packageInit.installTemplate()
-            try cmd("mkdir", "-p", ".github/workflows").run()
-            for workflow in try FileManager.default.contentsOfDirectory(atPath: ".github/workflows") {
-                if workflow.hasPrefix("GENERATED-") {
-                    try cmd("rm", ".github/workflows/\(workflow)").run()
+
+            if config.ciGenerateWorkflowFiles ?? true {
+                try cmd("mkdir", "-p", ".github/workflows").run()
+                for workflow in try FileManager.default.contentsOfDirectory(atPath: ".github/workflows") {
+                    if workflow.hasPrefix("GENERATED-") {
+                        try cmd("rm", ".github/workflows/\(workflow)").run()
+                    }
                 }
-            }
-            for workflow in try FileManager.default.contentsOfDirectory(atPath: "bindings/workflows") {
-                if workflow.hasPrefix("GENERATED-"), workflow.hasSuffix(".yaml") {
-                    try cmd("cp", "bindings/workflows/\(workflow)", ".github/workflows/\(workflow)").run()
+                for workflow in try FileManager.default.contentsOfDirectory(atPath: "bindings/workflows") {
+                    if workflow.hasPrefix("GENERATED-"), workflow.hasSuffix(".yaml") {
+                        try cmd("cp", "bindings/workflows/\(workflow)", ".github/workflows/\(workflow)").run()
+                    }
                 }
             }
         }

--- a/Sources/FishyJoesExecute/FishyJoesConfig.swift
+++ b/Sources/FishyJoesExecute/FishyJoesConfig.swift
@@ -8,6 +8,7 @@ struct FishyJoesConfig: Codable {
     let requiredModules: [String]
     let extraDynamicLibraries: [String]
     let excludeSources: [String]
+    let ciGenerateWorkflowFiles: Bool?
     let ciPreBuildHook: String?
 
     static func readFromFile(basePath: String) throws -> FishyJoesConfig {
@@ -57,6 +58,12 @@ struct FishyJoesConfig: Codable {
             }
             return list
         }
+        let ciGenerateWorkflowFiles = try configDictionary["CIGenerateWorkflowFiles"].map { obj -> Bool in
+            guard let hook = obj as? Bool else {
+                throw ValidationError("fishy-joes.yaml value for key `CIGenerateWorkflowFiles` is not a bool")
+            }
+            return hook
+        }
         let ciPreBuildHook = try configDictionary["CIPreBuildHook"].map { obj -> String in
             guard let hook = obj as? String else {
                 throw ValidationError("fishy-joes.yaml value for key `CIPreBuildHook` is not a (string) bash script")
@@ -69,6 +76,7 @@ struct FishyJoesConfig: Codable {
             requiredModules: requiredModules ?? [],
             extraDynamicLibraries: extraDynamicLibraries ?? [],
             excludeSources: excludeSources ?? [],
+            ciGenerateWorkflowFiles: ciGenerateWorkflowFiles,
             ciPreBuildHook: ciPreBuildHook
         )
     }

--- a/Sources/FishyJoesExecute/PackageInit.swift
+++ b/Sources/FishyJoesExecute/PackageInit.swift
@@ -86,6 +86,7 @@ public struct PackageInit: ParsableCommand {
             requiredModules: requiredModules.split(separator: " ").map(String.init),
             extraDynamicLibraries: extraDynamicLibraries.split(separator: " ").map(String.init),
             excludeSources: excludeSources.split(separator: " ").map(String.init),
+            ciGenerateWorkflowFiles: nil,
             ciPreBuildHook: nil
         )
 


### PR DESCRIPTION
Add an optional config param that allows us to skip the github workflow generation. For CriAnalytics this will allow the code generation to happen as part of the build - allowing folks to make changes to the event definitions only.

https://github.com/cricut/CriAnalytics/tree/main/Sources/EventDefinitions
