### PR TITLE
make regenerate-check attach a downloadable patch

### DIFF
--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-regenerate-check.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-regenerate-check.yaml
@@ -55,6 +55,7 @@ jobs:
           fi
 
       - name: Upload patch if needed
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: regenerated.patch

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-regenerate-check.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-regenerate-check.yaml
@@ -55,7 +55,7 @@ jobs:
           fi
 
       - name: Upload patch if needed
-        if: failed()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: regenerated.patch

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-regenerate-check.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-regenerate-check.yaml
@@ -46,9 +46,17 @@ jobs:
           swift run -- fishy-joes generate
 
           if [ ! -z "$(git status --porcelain .)" ]; then
-            git diff
+            git diff | tee regenerated.patch
             git status
             echo '::error:: generation modified sources'
             echo '::error::   run `FISHYJOES=1 swift run fishy-joes generate` from root of repository and re-commit'
+            echo '::error::   (alternatively, download patch attached to this workflow and run `git apply regenerated.patch`)'
             exit 1
           fi
+
+      - name: Upload patch if needed
+        uses: actions/upload-artifact@v4
+        with:
+          name: regenerated.patch
+          path: regenerated.patch
+          if-no-files-found: ignore

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-regenerate-check.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-regenerate-check.yaml
@@ -55,7 +55,7 @@ jobs:
           fi
 
       - name: Upload patch if needed
-        if: always()
+        if: failed()
         uses: actions/upload-artifact@v4
         with:
           name: regenerated.patch

--- a/Sources/SourceryDataModel/SourceryDataModel.swift
+++ b/Sources/SourceryDataModel/SourceryDataModel.swift
@@ -206,6 +206,7 @@ public struct SourceryAttribute: Hashable, Codable {
 // MARK: convertion from sourcery types to transport types
 
 #if canImport(SourceryRuntime)
+import Foundation
 import SourceryRuntime
 
 extension SourceryTemplateContext {

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-regenerate-check.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-regenerate-check.yaml
@@ -55,6 +55,7 @@ jobs:
           fi
 
       - name: Upload patch if needed
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: regenerated.patch

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-regenerate-check.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-regenerate-check.yaml
@@ -55,7 +55,7 @@ jobs:
           fi
 
       - name: Upload patch if needed
-        if: failed()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: regenerated.patch

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-regenerate-check.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-regenerate-check.yaml
@@ -46,9 +46,17 @@ jobs:
           swift run -- fishy-joes generate
 
           if [ ! -z "$(git status --porcelain .)" ]; then
-            git diff
+            git diff | tee regenerated.patch
             git status
             echo '::error:: generation modified sources'
             echo '::error::   run `FISHYJOES=1 swift run fishy-joes generate` from root of repository and re-commit'
+            echo '::error::   (alternatively, download patch attached to this workflow and run `git apply regenerated.patch`)'
             exit 1
           fi
+
+      - name: Upload patch if needed
+        uses: actions/upload-artifact@v4
+        with:
+          name: regenerated.patch
+          path: regenerated.patch
+          if-no-files-found: ignore

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-regenerate-check.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-regenerate-check.yaml
@@ -55,7 +55,7 @@ jobs:
           fi
 
       - name: Upload patch if needed
-        if: always()
+        if: failed()
         uses: actions/upload-artifact@v4
         with:
           name: regenerated.patch

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-regenerate-check.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-regenerate-check.yaml
@@ -55,6 +55,7 @@ jobs:
           fi
 
       - name: Upload patch if needed
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: regenerated.patch

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-regenerate-check.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-regenerate-check.yaml
@@ -55,7 +55,7 @@ jobs:
           fi
 
       - name: Upload patch if needed
-        if: failed()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: regenerated.patch

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-regenerate-check.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-regenerate-check.yaml
@@ -46,9 +46,17 @@ jobs:
           swift run -- fishy-joes generate
 
           if [ ! -z "$(git status --porcelain .)" ]; then
-            git diff
+            git diff | tee regenerated.patch
             git status
             echo '::error:: generation modified sources'
             echo '::error::   run `FISHYJOES=1 swift run fishy-joes generate` from root of repository and re-commit'
+            echo '::error::   (alternatively, download patch attached to this workflow and run `git apply regenerated.patch`)'
             exit 1
           fi
+
+      - name: Upload patch if needed
+        uses: actions/upload-artifact@v4
+        with:
+          name: regenerated.patch
+          path: regenerated.patch
+          if-no-files-found: ignore

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-regenerate-check.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-regenerate-check.yaml
@@ -55,7 +55,7 @@ jobs:
           fi
 
       - name: Upload patch if needed
-        if: always()
+        if: failed()
         uses: actions/upload-artifact@v4
         with:
           name: regenerated.patch


### PR DESCRIPTION
If the regenerate-check workflow fails, it will now generate and attach a patch file to the workflow with instructions on how to apply it. This provides an alternative for people who can't run fishy-joes generate and still need to develop.

Example failure: https://github.com/cricut/CriGeo/actions/runs/18538689082/job/52840389368