### PR TITLE
feat: add --flexible-versions flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,32 @@ git diff
 
 These are recommendations only, take or leave the changes.
 
+## Command Line Options
+
+### Dependency version control
+
+By default, FishyJoes translates Swift Package Manager dependency versions to exact versions in generated packages. Use `--flexible-versions` to generate flexible version constraints instead.
+
+Without `--flexible-versions`:
+- NuGet: `[2.19.4]`
+- NPM/Dart: `2.19.4`
+- Gradle: `2.19.4`
+
+With `--flexible-versions`:
+- NuGet: `[2.19.4,3.0.0)` for upToNextMajor constraints
+- NPM/Dart: `^2.19.4` for upToNextMajor, `~1.2.3` for upToNextMinor
+- Gradle: `2.19.4` (always exact)
+
+Example:
+```
+swift run fishy-joes --kotlin-fast --flexible-versions generate build test
+```
+
+The `--flexible-versions` flag translates Swift Package Manager version constraints:
+- `.upToNextMajor` to caret notation (`^`) or bracket ranges
+- `.upToNextMinor` to tilde notation (`~`) or bracket ranges
+- `.exact`, `.revision`, `.branch` remain exact regardless of flag
+
 ## Updating exported library
 
 0. Update version in Package.swift

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -44,9 +44,6 @@ public class CodeGen: ParsableCommand {
     @Flag(name: .long, help: #"Disable parallelism for swift build. (If you get a "FishyJoesCommonRuntime-Swift.h" or "TestAPI-Swift.h" file not found error, try this option)"#)
     var disableParallelism = false
 
-    @Flag(name: .long, help: "Translate Swift Package.swift dependency version ranges to flexible versions (^, ~, >=) in generated packages")
-    var flexibleVersions = false
-
     enum BuildStep: String, CaseIterable, ExpressibleByArgument {
         case generate, build, test, pack
     }
@@ -80,7 +77,6 @@ public class CodeGen: ParsableCommand {
         case swiftly
         case fat
         case disableParallelism
-        case flexibleVersions
     }
 
     var config: FishyJoesConfig!

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -44,6 +44,9 @@ public class CodeGen: ParsableCommand {
     @Flag(name: .long, help: #"Disable parallelism for swift build. (If you get a "FishyJoesCommonRuntime-Swift.h" or "TestAPI-Swift.h" file not found error, try this option)"#)
     var disableParallelism = false
 
+    @Flag(name: .long, help: "Translate Swift Package.swift dependency version ranges to flexible versions (^, ~, >=) in generated packages")
+    var flexibleVersions = false
+
     enum BuildStep: String, CaseIterable, ExpressibleByArgument {
         case generate, build, test, pack
     }
@@ -77,6 +80,7 @@ public class CodeGen: ParsableCommand {
         case swiftly
         case fat
         case disableParallelism
+        case flexibleVersions
     }
 
     var config: FishyJoesConfig!

--- a/Sources/FishyJoesExecute/FishyJoesConfig.swift
+++ b/Sources/FishyJoesExecute/FishyJoesConfig.swift
@@ -10,6 +10,7 @@ struct FishyJoesConfig: Codable {
     let extraDynamicLibraries: [String]
     let excludeSources: [String]
     let ciPreBuildHook: String?
+    let flexibleVersions: Bool
 
     // Sometimes sourcery has conflicts with a particular macos or xcode
     // version, so while not recommended normally, this can be used to work
@@ -86,6 +87,7 @@ struct FishyJoesConfig: Codable {
                 throw ValidationError(#"fishy-joes.yaml value for key `sourceryOverride` is \#(obj), not e.g. `{"remote": "krzysztofzablocki/Sourcery@x.y.z"}`, `{"local": "/path/to/sourcery"}`, or `{"local": null}`"#)
             }
         }
+        let flexibleVersions = (configDictionary["flexibleVersions"] as? Bool) ?? false
 
         return FishyJoesConfig(
             module: module,
@@ -94,6 +96,7 @@ struct FishyJoesConfig: Codable {
             extraDynamicLibraries: extraDynamicLibraries ?? [],
             excludeSources: excludeSources ?? [],
             ciPreBuildHook: ciPreBuildHook,
+            flexibleVersions: flexibleVersions,
             sourceryOverride: sourceryOverride
         )
     }

--- a/Sources/FishyJoesExecute/PackageInit.swift
+++ b/Sources/FishyJoesExecute/PackageInit.swift
@@ -86,6 +86,7 @@ public struct PackageInit: ParsableCommand {
             extraDynamicLibraries: extraDynamicLibraries.split(separator: " ").map(String.init),
             excludeSources: excludeSources.split(separator: " ").map(String.init),
             ciPreBuildHook: nil,
+            flexibleVersions: false,
             sourceryOverride: nil
         )
 

--- a/Sources/FishyJoesExecute/Phases/CSharpPhases.swift
+++ b/Sources/FishyJoesExecute/Phases/CSharpPhases.swift
@@ -18,7 +18,7 @@ class CSharpPhases: IotaPhases, Phases {
                 guard let dependency = options.packageInfo?.dependencyMap[$0.swift] else {
                     return #"<ItemGroup><PackageReference Include="\#($0.nuget)" Version="[0.0.1-unknown]" /></ItemGroup>"#
                 }
-                if let version = dependency.versionInNugetFormat(flexibleVersions: options.flexibleVersions) {
+                if let version = dependency.versionInNugetFormat(flexibleVersions: options.config.flexibleVersions) {
                     return #"<ItemGroup><PackageReference Include="\#($0.nuget)" Version="\#(version)" /></ItemGroup>"#
                 } else {
                     let path = relativePath(of: dependency.localPath, relativeTo: "bindings/c-sharp/generated/Cricut.\(options.config.module)/")

--- a/Sources/FishyJoesExecute/Phases/CSharpPhases.swift
+++ b/Sources/FishyJoesExecute/Phases/CSharpPhases.swift
@@ -18,7 +18,7 @@ class CSharpPhases: IotaPhases, Phases {
                 guard let dependency = options.packageInfo?.dependencyMap[$0.swift] else {
                     return #"<ItemGroup><PackageReference Include="\#($0.nuget)" Version="[0.0.1-unknown]" /></ItemGroup>"#
                 }
-                if let version = dependency.versionInNugetFormat {
+                if let version = dependency.versionInNugetFormat(flexibleVersions: options.flexibleVersions) {
                     return #"<ItemGroup><PackageReference Include="\#($0.nuget)" Version="\#(version)" /></ItemGroup>"#
                 } else {
                     let path = relativePath(of: dependency.localPath, relativeTo: "bindings/c-sharp/generated/Cricut.\(options.config.module)/")

--- a/Sources/FishyJoesExecute/Phases/DartPhases.swift
+++ b/Sources/FishyJoesExecute/Phases/DartPhases.swift
@@ -28,7 +28,7 @@ class DartPhases: IotaPhases, Phases {
                     "  path: DEPENDENCY_NOT_FOUND",
                 ]
             }
-            if let version = dependency.versionInPubspecFormat(flexibleVersions: options.flexibleVersions) {
+            if let version = dependency.versionInPubspecFormat(flexibleVersions: options.config.flexibleVersions) {
                 return lines + [
                     #"  git:"#,
                     #"    url: "https://github.com/cricut/\#(depNames.swift).git""#,
@@ -55,7 +55,7 @@ class DartPhases: IotaPhases, Phases {
                 .versionInNpmFormat(
                     relativeTo: "bindings/dart/generated/flutter-package/",
                     addIfLocalPath: dependency.npmSubPath,
-                    flexibleVersions: options.flexibleVersions
+                    flexibleVersions: options.config.flexibleVersions
                 )
                 ?? "0.0.1-unknown"
             return #""@cricut/\#(dependency.npm)": "\#(version)""#

--- a/Sources/FishyJoesExecute/Phases/DartPhases.swift
+++ b/Sources/FishyJoesExecute/Phases/DartPhases.swift
@@ -28,7 +28,7 @@ class DartPhases: IotaPhases, Phases {
                     "  path: DEPENDENCY_NOT_FOUND",
                 ]
             }
-            if let version = dependency.versionInPubspecFormat {
+            if let version = dependency.versionInPubspecFormat(flexibleVersions: options.flexibleVersions) {
                 return lines + [
                     #"  git:"#,
                     #"    url: "https://github.com/cricut/\#(depNames.swift).git""#,
@@ -54,7 +54,8 @@ class DartPhases: IotaPhases, Phases {
             let version = options.packageInfo?.dependencyMap[dependency.swift]?
                 .versionInNpmFormat(
                     relativeTo: "bindings/dart/generated/flutter-package/",
-                    addIfLocalPath: dependency.npmSubPath
+                    addIfLocalPath: dependency.npmSubPath,
+                    flexibleVersions: options.flexibleVersions
                 )
                 ?? "0.0.1-unknown"
             return #""@cricut/\#(dependency.npm)": "\#(version)""#

--- a/Sources/FishyJoesExecute/Phases/KotlinPhases.swift
+++ b/Sources/FishyJoesExecute/Phases/KotlinPhases.swift
@@ -11,7 +11,7 @@ class KotlinPhases: BasePhases, Phases {
             (swift: $0, groupId: "com.cricut.\($0)", artifactId: $0.lowercased())
         }
         let gradleDependencyLines = gradleDependencies.map { dependency in
-            let version = options.packageInfo?.dependencyMap[dependency.swift]?.versionInGradleFormat ?? "local"
+            let version = options.packageInfo?.dependencyMap[dependency.swift]?.versionInGradleFormat(flexibleVersions: options.flexibleVersions) ?? "local"
             return "api(\"\(dependency.groupId):\(dependency.artifactId):\(version)\")"
         }
         replacements["__GRADLE_DEPENDENCIES__"] = join(lines: gradleDependencyLines, indent: 4)

--- a/Sources/FishyJoesExecute/Phases/KotlinPhases.swift
+++ b/Sources/FishyJoesExecute/Phases/KotlinPhases.swift
@@ -11,7 +11,7 @@ class KotlinPhases: BasePhases, Phases {
             (swift: $0, groupId: "com.cricut.\($0)", artifactId: $0.lowercased())
         }
         let gradleDependencyLines = gradleDependencies.map { dependency in
-            let version = options.packageInfo?.dependencyMap[dependency.swift]?.versionInGradleFormat(flexibleVersions: options.flexibleVersions) ?? "local"
+            let version = options.packageInfo?.dependencyMap[dependency.swift]?.versionInGradleFormat(flexibleVersions: options.config.flexibleVersions) ?? "local"
             return "api(\"\(dependency.groupId):\(dependency.artifactId):\(version)\")"
         }
         replacements["__GRADLE_DEPENDENCIES__"] = join(lines: gradleDependencyLines, indent: 4)

--- a/Sources/FishyJoesExecute/Phases/NodePhases.swift
+++ b/Sources/FishyJoesExecute/Phases/NodePhases.swift
@@ -27,7 +27,7 @@ class NodePhases: BasePhases, Phases {
                     .versionInNpmFormat(
                         relativeTo: "bindings/ts/generated/packages/node-native\(platform)",
                         addIfLocalPath: dependency.subPath,
-                        flexibleVersions: options.flexibleVersions
+                        flexibleVersions: options.config.flexibleVersions
                     )
                     ?? "0.0.1-unknown"
                 return #""@cricut/\#(dependency.npm)": "\#(version)""#

--- a/Sources/FishyJoesExecute/Phases/NodePhases.swift
+++ b/Sources/FishyJoesExecute/Phases/NodePhases.swift
@@ -26,7 +26,8 @@ class NodePhases: BasePhases, Phases {
                 let version = options.packageInfo?.dependencyMap[dependency.swift]?
                     .versionInNpmFormat(
                         relativeTo: "bindings/ts/generated/packages/node-native\(platform)",
-                        addIfLocalPath: dependency.subPath
+                        addIfLocalPath: dependency.subPath,
+                        flexibleVersions: options.flexibleVersions
                     )
                     ?? "0.0.1-unknown"
                 return #""@cricut/\#(dependency.npm)": "\#(version)""#

--- a/Sources/FishyJoesExecute/SwiftPackage.swift
+++ b/Sources/FishyJoesExecute/SwiftPackage.swift
@@ -104,6 +104,12 @@ extension SwiftPackage.Dependency {
     }
 
     func versionInGradleFormat(flexibleVersions: Bool = false) -> String {
+        // The flexibleVersions parameter is intentionally unused for Gradle.
+        // Gradle's version constraint solver has limitations with complex range constraints
+        // (see https://github.com/gradle/gradle/issues/8126). For consistency and reliability
+        // across build environments, we always use exact versions for Gradle, regardless of the flag.
+        // As a temporary solution for Android, the cri-next-major-resolver plugin
+        // (https://github.com/cricut/cri-next-major-resolver) can be used to resolve version constraints.
         let spec: String
         switch self {
         case .sourceControl(_, _, .branch(let name)):
@@ -122,6 +128,7 @@ extension SwiftPackage.Dependency {
             spec = "local"
         }
 
+        // Convert anything like "user/branch" into things gradle can parse, even if it probably won't find a release by that name
         return spec.replacingOccurrences(of: "/", with: "-")
     }
 

--- a/Sources/FishyJoesExecute/SwiftPackage.swift
+++ b/Sources/FishyJoesExecute/SwiftPackage.swift
@@ -103,11 +103,7 @@ extension SwiftPackage.Dependency {
         return url.scheme == "file" || url.scheme == nil ? url.path : ".build/checkouts/\(url.lastPathComponent)"
     }
 
-    var versionInGradleFormat: String {
-        // TODO: figure out how to use gradle version ranges. The solver may not be good enough for this to work properly.
-        // See for example: https://github.com/gradle/gradle/issues/8126
-
-        // https://docs.gradle.org/current/userguide/single_versions.html
+    func versionInGradleFormat(flexibleVersions: Bool = false) -> String {
         let spec: String
         switch self {
         case .sourceControl(_, _, .branch(let name)):
@@ -115,13 +111,10 @@ extension SwiftPackage.Dependency {
         case .sourceControl(_, _, .revision(let name)):
             spec = name
         case .sourceControl(_, _, .upToNextMajor(let baseVersion)):
-            // spec = "[\(baseVersion),\(baseVersion.nextMajor))"
             spec = baseVersion.versionString
         case .sourceControl(_, _, .upToNextMinor(let baseVersion)):
-            // spec = "[\(baseVersion),\(baseVersion.nextMinor))"
             spec = baseVersion.versionString
         case .sourceControl(_, _, .range(let lowerBound, _)):
-            // spec = "[\(lowerBound),\(upperBound))"
             spec = lowerBound.versionString
         case .sourceControl(_, _, .exact(let version)):
             spec = version.versionString
@@ -129,27 +122,37 @@ extension SwiftPackage.Dependency {
             spec = "local"
         }
 
-        // Convert anything like "user/branch" into things gradle can parse, even if it probably won't find a release by that name
         return spec.replacingOccurrences(of: "/", with: "-")
     }
 
-    var versionInNugetFormat: String? {
-        // TODO: Enable nuget version ranges. Should be working, but not enabled to be consistent with other languages
-        // https://learn.microsoft.com/en-us/nuget/concepts/package-versioning
+    func versionInNugetFormat(flexibleVersions: Bool = false) -> String? {
         switch self {
         case .sourceControl(_, _, .branch(let name)):
             return "[\(name)]"
         case .sourceControl(_, _, .revision(let name)):
             return "[\(name)]"
         case .sourceControl(_, _, .upToNextMajor(let baseVersion)):
-            // return "[\(baseVersion),\(baseVersion.nextMajor))"
-            return "[\(baseVersion)]"
+            if flexibleVersions {
+                if baseVersion.major > 0 {
+                    return "[\(baseVersion),\(baseVersion.nextMajor))"
+                } else {
+                    return "[\(baseVersion),\(baseVersion.nextMajor))"
+                }
+            } else {
+                return "[\(baseVersion)]"
+            }
         case .sourceControl(_, _, .upToNextMinor(let baseVersion)):
-            // return "[\(baseVersion),\(baseVersion.nextMinor))"
-            return "[\(baseVersion)]"
-        case .sourceControl(_, _, .range(let lowerBound, _)):
-            // return "[\(lowerBound),\(upperBound))"
-            return "[\(lowerBound)]"
+            if flexibleVersions {
+                return "[\(baseVersion),\(baseVersion.nextMinor))"
+            } else {
+                return "[\(baseVersion)]"
+            }
+        case .sourceControl(_, _, .range(let lowerBound, let upperBound)):
+            if flexibleVersions {
+                return "[\(lowerBound),\(upperBound))"
+            } else {
+                return "[\(lowerBound)]"
+            }
         case .sourceControl(_, _, .exact(let version)):
             return "[\(version)]"
         case .fileSystem:
@@ -157,29 +160,34 @@ extension SwiftPackage.Dependency {
         }
     }
 
-    func versionInNpmFormat(relativeTo: String?, addIfLocalPath: String = "") -> String {
-        // TODO: Enable npm version ranges. Should be working, but not enabled to be consistent with other languages
-
-        // These examples are the most authoritative source I could find without digging into the code of npm itself...
-        // https://semver.npmjs.com/#syntax-examples
+    func versionInNpmFormat(relativeTo: String?, addIfLocalPath: String = "", flexibleVersions: Bool = false) -> String {
         switch self {
         case .sourceControl(_, _, .branch(let name)):
             return name
         case .sourceControl(_, _, .revision(let name)):
             return name
         case .sourceControl(_, _, .upToNextMajor(let baseVersion)):
-            // if baseVersion.major > 0 {
-            //     return "^\(baseVersion)"
-            // } else {
-            //     return ">=\(baseVersion) <\(baseVersion.nextMajor)"
-            // }
-            return baseVersion.versionString
+            if flexibleVersions {
+                if baseVersion.major > 0 {
+                    return "^\(baseVersion)"
+                } else {
+                    return ">=\(baseVersion) <\(baseVersion.nextMajor)"
+                }
+            } else {
+                return baseVersion.versionString
+            }
         case .sourceControl(_, _, .upToNextMinor(let baseVersion)):
-            // return "~\(baseVersion)"
-            return baseVersion.versionString
-        case .sourceControl(_, _, .range(let lowerBound, _)):
-            // return ">=\(lowerBound) <\(upperBound)"
-            return lowerBound.versionString
+            if flexibleVersions {
+                return "~\(baseVersion)"
+            } else {
+                return baseVersion.versionString
+            }
+        case .sourceControl(_, _, .range(let lowerBound, let upperBound)):
+            if flexibleVersions {
+                return ">=\(lowerBound) <\(upperBound)"
+            } else {
+                return lowerBound.versionString
+            }
         case .sourceControl(_, _, .exact(let version)):
             return version.versionString
         case .fileSystem(_, let absolutePath):
@@ -188,27 +196,34 @@ extension SwiftPackage.Dependency {
         }
     }
 
-    var versionInPubspecFormat: String? {
-        // TODO: figure out how to use pubspec version ranges. Needs non-git hosting.
-        // https://dart.dev/tools/pub/versioning
+    func versionInPubspecFormat(flexibleVersions: Bool = false) -> String? {
         switch self {
         case .sourceControl(_, _, .branch(let name)):
             return name
         case .sourceControl(_, _, .revision(let name)):
             return name
         case .sourceControl(_, _, .upToNextMajor(let baseVersion)):
-            // if baseVersion.major > 0 {
-            //     return "^\(baseVersion)"
-            // } else {
-            //     return ">=\(baseVersion) <\(baseVersion.nextMajor)"
-            // }
-            return baseVersion.versionString
+            if flexibleVersions {
+                if baseVersion.major > 0 {
+                    return "^\(baseVersion)"
+                } else {
+                    return ">=\(baseVersion) <\(baseVersion.nextMajor)"
+                }
+            } else {
+                return baseVersion.versionString
+            }
         case .sourceControl(_, _, .upToNextMinor(let baseVersion)):
-            // return "~\(baseVersion)"
-            return baseVersion.versionString
-        case .sourceControl(_, _, .range(let lowerBound, _)):
-            // return ">=\(lowerBound) <\(upperBound)"
-            return lowerBound.versionString
+            if flexibleVersions {
+                return "~\(baseVersion)"
+            } else {
+                return baseVersion.versionString
+            }
+        case .sourceControl(_, _, .range(let lowerBound, let upperBound)):
+            if flexibleVersions {
+                return ">=\(lowerBound) <\(upperBound)"
+            } else {
+                return lowerBound.versionString
+            }
         case .sourceControl(_, _, .exact(let version)):
             return version.versionString
         case .fileSystem:
@@ -248,7 +263,15 @@ extension SwiftPackage.Dependency.Requirement: Decodable {
             let lowerBound = ranges[0]["lowerBound"].flatMap(SemanticVersion.init),
             let upperBound = ranges[0]["upperBound"].flatMap(SemanticVersion.init)
         {
-            self = .range(lowerBound: lowerBound, upperBound: upperBound)
+            // Swift 6.1+ encodes upToNextMajor/upToNextMinor as explicit ranges
+            // Try to detect and reconstruct the semantic intent
+            if upperBound == lowerBound.nextMinor {
+                self = .upToNextMinor(baseVersion: lowerBound)
+            } else if upperBound == lowerBound.nextMajor {
+                self = .upToNextMajor(baseVersion: lowerBound)
+            } else {
+                self = .range(lowerBound: lowerBound, upperBound: upperBound)
+            }
         } else if let branchNames = try? container.decode([String].self, forKey: .branch), branchNames.count == 1 {
             self = .branch(name: branchNames[0])
         } else if let revisionNames = try? container.decode([String].self, forKey: .revision), revisionNames.count == 1 {

--- a/Sources/FishyJoesExecute/SwiftPackage.swift
+++ b/Sources/FishyJoesExecute/SwiftPackage.swift
@@ -140,11 +140,7 @@ extension SwiftPackage.Dependency {
             return "[\(name)]"
         case .sourceControl(_, _, .upToNextMajor(let baseVersion)):
             if flexibleVersions {
-                if baseVersion.major > 0 {
-                    return "[\(baseVersion),\(baseVersion.nextMajor))"
-                } else {
-                    return "[\(baseVersion),\(baseVersion.nextMajor))"
-                }
+                return "[\(baseVersion),\(baseVersion.nextMajor))"
             } else {
                 return "[\(baseVersion)]"
             }

--- a/Tests/FishyJoesExecuteTests/SwiftPackageTests.swift
+++ b/Tests/FishyJoesExecuteTests/SwiftPackageTests.swift
@@ -8,9 +8,9 @@ class SwiftPackageTests: XCTestCase {
         let parsed = try JSONDecoder().decode(SwiftPackage.self, from: Data(contentsOf: jsonURL))
 
         XCTAssertEqual(parsed.dependencyMap["fishyjoes"]?.url, URL(fileURLWithPath: "/Users/acobb/src/FishyJoes"))
-        XCTAssertEqual(parsed.dependencyMap["fishyjoes"]?.versionInGradleFormat, "local")
+        XCTAssertEqual(parsed.dependencyMap["fishyjoes"]?.versionInGradleFormat(), "local")
         XCTAssertEqual(parsed.dependencyMap["crigeo"]?.url, URL(string: "https://github.com/cricut/CriGeo"))
-        XCTAssertEqual(parsed.dependencyMap["crigeo"]?.versionInGradleFormat, "0.14.2")
+        XCTAssertEqual(parsed.dependencyMap["crigeo"]?.versionInGradleFormat(), "0.14.2")
     }
 
     func testSwift5_6() throws {
@@ -19,9 +19,9 @@ class SwiftPackageTests: XCTestCase {
         let parsed = try JSONDecoder().decode(SwiftPackage.self, from: Data(contentsOf: jsonURL))
 
         XCTAssertEqual(parsed.dependencyMap["fishyjoes"]?.url, URL(fileURLWithPath: "/Users/mstoker/.cricut/FishyJoes"))
-        XCTAssertEqual(parsed.dependencyMap["fishyjoes"]?.versionInGradleFormat, "local")
+        XCTAssertEqual(parsed.dependencyMap["fishyjoes"]?.versionInGradleFormat(), "local")
         XCTAssertEqual(parsed.dependencyMap["crigeo"]?.url, URL(string: "https://github.com/cricut/CriGeo"))
-        XCTAssertEqual(parsed.dependencyMap["crigeo"]?.versionInGradleFormat, "fishy-joes-annotations")
+        XCTAssertEqual(parsed.dependencyMap["crigeo"]?.versionInGradleFormat(), "fishy-joes-annotations")
     }
 
     func testSwift5_8() throws {
@@ -30,9 +30,9 @@ class SwiftPackageTests: XCTestCase {
         let parsed = try JSONDecoder().decode(SwiftPackage.self, from: Data(contentsOf: jsonURL))
 
         XCTAssertEqual(parsed.dependencyMap["fishyjoes"]?.url, URL(string: "https://github.com/cricut/FishyJoes"))
-        XCTAssertEqual(parsed.dependencyMap["fishyjoes"]?.versionInGradleFormat, "4.0.0-alpha2")
+        XCTAssertEqual(parsed.dependencyMap["fishyjoes"]?.versionInGradleFormat(), "4.0.0-alpha2")
         XCTAssertEqual(parsed.dependencyMap["crigeo"]?.url, URL(string: "https://github.com/cricut/CriGeo"))
-        XCTAssertEqual(parsed.dependencyMap["crigeo"]?.versionInGradleFormat, "2.3.0")
+        XCTAssertEqual(parsed.dependencyMap["crigeo"]?.versionInGradleFormat(), "2.3.0")
     }
 
     func testSwift5_10() throws {
@@ -41,6 +41,6 @@ class SwiftPackageTests: XCTestCase {
         let parsed = try JSONDecoder().decode(SwiftPackage.self, from: Data(contentsOf: jsonURL))
 
         XCTAssertEqual(parsed.dependencyMap["fishyjoes"]?.url, URL(string: "https://github.com/cricut/FishyJoes"))
-        XCTAssertEqual(parsed.dependencyMap["fishyjoes"]?.versionInGradleFormat, "4.7.8-alpha2")
+        XCTAssertEqual(parsed.dependencyMap["fishyjoes"]?.versionInGradleFormat(), "4.7.8-alpha2")
     }
 }

--- a/Tests/FishyJoesExecuteTests/SwiftPackageVersionFormatTests.swift
+++ b/Tests/FishyJoesExecuteTests/SwiftPackageVersionFormatTests.swift
@@ -1,0 +1,132 @@
+@testable import FishyJoesExecute
+import XCTest
+
+class SwiftPackageVersionFormatTests: XCTestCase {
+    let testURL = URL(string: "https://example.com")!
+
+    func testVersionFormatNuget() throws {
+        let upToNextMajor = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .upToNextMajor(baseVersion: SemanticVersion(major: 2, minor: 19, patch: 4))
+        )
+        let upToNextMinor = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .upToNextMinor(baseVersion: SemanticVersion(major: 1, minor: 2, patch: 3))
+        )
+        let exact = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .exact(version: SemanticVersion(major: 1, minor: 11, patch: 11))
+        )
+        let revision = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .revision(name: "abc123")
+        )
+        let range = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .range(
+                lowerBound: SemanticVersion(major: 1, minor: 0, patch: 0),
+                upperBound: SemanticVersion(major: 2, minor: 0, patch: 0)
+            )
+        )
+
+        XCTAssertEqual(upToNextMajor.versionInNugetFormat(flexibleVersions: false), "[2.19.4]")
+        XCTAssertEqual(upToNextMajor.versionInNugetFormat(flexibleVersions: true), "[2.19.4,3.0.0)")
+        XCTAssertEqual(upToNextMinor.versionInNugetFormat(flexibleVersions: false), "[1.2.3]")
+        XCTAssertEqual(upToNextMinor.versionInNugetFormat(flexibleVersions: true), "[1.2.3,1.3.0)")
+        XCTAssertEqual(exact.versionInNugetFormat(flexibleVersions: false), "[1.11.11]")
+        XCTAssertEqual(exact.versionInNugetFormat(flexibleVersions: true), "[1.11.11]")
+        XCTAssertEqual(revision.versionInNugetFormat(flexibleVersions: false), "[abc123]")
+        XCTAssertEqual(revision.versionInNugetFormat(flexibleVersions: true), "[abc123]")
+        XCTAssertEqual(range.versionInNugetFormat(flexibleVersions: false), "[1.0.0]")
+        XCTAssertEqual(range.versionInNugetFormat(flexibleVersions: true), "[1.0.0,2.0.0)")
+    }
+
+    func testVersionFormatNpm() throws {
+        let upToNextMajor = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .upToNextMajor(baseVersion: SemanticVersion(major: 2, minor: 19, patch: 4))
+        )
+        let upToNextMajorZero = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .upToNextMajor(baseVersion: SemanticVersion(major: 0, minor: 5, patch: 0))
+        )
+        let upToNextMinor = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .upToNextMinor(baseVersion: SemanticVersion(major: 1, minor: 2, patch: 3))
+        )
+        let exact = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .exact(version: SemanticVersion(major: 1, minor: 11, patch: 11))
+        )
+        let revision = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .revision(name: "abc123")
+        )
+        let range = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .range(
+                lowerBound: SemanticVersion(major: 1, minor: 0, patch: 0),
+                upperBound: SemanticVersion(major: 2, minor: 0, patch: 0)
+            )
+        )
+
+        XCTAssertEqual(upToNextMajor.versionInNpmFormat(relativeTo: nil, flexibleVersions: false), "2.19.4")
+        XCTAssertEqual(upToNextMajor.versionInNpmFormat(relativeTo: nil, flexibleVersions: true), "^2.19.4")
+        XCTAssertEqual(upToNextMajorZero.versionInNpmFormat(relativeTo: nil, flexibleVersions: true), ">=0.5.0 <1.0.0")
+        XCTAssertEqual(upToNextMinor.versionInNpmFormat(relativeTo: nil, flexibleVersions: false), "1.2.3")
+        XCTAssertEqual(upToNextMinor.versionInNpmFormat(relativeTo: nil, flexibleVersions: true), "~1.2.3")
+        XCTAssertEqual(exact.versionInNpmFormat(relativeTo: nil, flexibleVersions: false), "1.11.11")
+        XCTAssertEqual(exact.versionInNpmFormat(relativeTo: nil, flexibleVersions: true), "1.11.11")
+        XCTAssertEqual(revision.versionInNpmFormat(relativeTo: nil, flexibleVersions: false), "abc123")
+        XCTAssertEqual(revision.versionInNpmFormat(relativeTo: nil, flexibleVersions: true), "abc123")
+        XCTAssertEqual(range.versionInNpmFormat(relativeTo: nil, flexibleVersions: false), "1.0.0")
+        XCTAssertEqual(range.versionInNpmFormat(relativeTo: nil, flexibleVersions: true), ">=1.0.0 <2.0.0")
+    }
+
+    func testVersionFormatPubspec() throws {
+        let upToNextMajor = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .upToNextMajor(baseVersion: SemanticVersion(major: 2, minor: 19, patch: 4))
+        )
+        let upToNextMinor = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .upToNextMinor(baseVersion: SemanticVersion(major: 1, minor: 2, patch: 3))
+        )
+        let exact = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .exact(version: SemanticVersion(major: 1, minor: 11, patch: 11))
+        )
+
+        XCTAssertEqual(upToNextMajor.versionInPubspecFormat(flexibleVersions: false), "2.19.4")
+        XCTAssertEqual(upToNextMajor.versionInPubspecFormat(flexibleVersions: true), "^2.19.4")
+        XCTAssertEqual(upToNextMinor.versionInPubspecFormat(flexibleVersions: false), "1.2.3")
+        XCTAssertEqual(upToNextMinor.versionInPubspecFormat(flexibleVersions: true), "~1.2.3")
+        XCTAssertEqual(exact.versionInPubspecFormat(flexibleVersions: false), "1.11.11")
+        XCTAssertEqual(exact.versionInPubspecFormat(flexibleVersions: true), "1.11.11")
+    }
+
+    func testVersionFormatGradle() throws {
+        let upToNextMajor = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .upToNextMajor(baseVersion: SemanticVersion(major: 2, minor: 19, patch: 4))
+        )
+
+        XCTAssertEqual(upToNextMajor.versionInGradleFormat(flexibleVersions: false), "2.19.4")
+        XCTAssertEqual(upToNextMajor.versionInGradleFormat(flexibleVersions: true), "2.19.4")
+    }
+}


### PR DESCRIPTION
## Summary
Add `--flexible-versions` flag to translate Swift Package.swift dependency version ranges to flexible version constraints in
generated packages.

## Changes
- NuGet: bracket ranges `[2.19.4,3.0.0)`
- NPM/Dart: caret `^` and tilde `~` notation
- Gradle: exact versions (unchanged)

## Details
- Convert version formatting methods from properties to functions
- Update all phase files (C#, Dart, Kotlin, Node)
- Smart Swift 6.1+ range decoding
- Update tests

## Usage
```bash
swift run fishy-joes --flexible-versions generate build test
```