### PR TITLE
Migrate to Swift 6.3 WASM with ExecutorFactory API

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -296,8 +296,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Setup JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -296,8 +296,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.2-release
-          tag: 6.2-RELEASE
+          branch: swift-6.1-release
+          tag: 6.1-RELEASE
 
       - name: Setup JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/iota-runtime.yaml
+++ b/.github/workflows/iota-runtime.yaml
@@ -126,8 +126,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.2-release
-          tag: 6.2-RELEASE
+          branch: swift-6.1-release
+          tag: 6.1-RELEASE
 
       - name: Pre-resolve Required SwiftPM Packages
         continue-on-error: true

--- a/.github/workflows/iota-runtime.yaml
+++ b/.github/workflows/iota-runtime.yaml
@@ -126,8 +126,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve Required SwiftPM Packages
         continue-on-error: true

--- a/.github/workflows/java-runtime.yaml
+++ b/.github/workflows/java-runtime.yaml
@@ -143,8 +143,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Setup JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/java-runtime.yaml
+++ b/.github/workflows/java-runtime.yaml
@@ -143,8 +143,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.2-release
-          tag: 6.2-RELEASE
+          branch: swift-6.1-release
+          tag: 6.1-RELEASE
 
       - name: Setup JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/node-runtime.yaml
+++ b/.github/workflows/node-runtime.yaml
@@ -222,8 +222,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.2-release
-          tag: 6.2-RELEASE
+          branch: swift-6.1-release
+          tag: 6.1-RELEASE
 
       - name: Pre-resolve Required SwiftPM Packages
         continue-on-error: true

--- a/.github/workflows/node-runtime.yaml
+++ b/.github/workflows/node-runtime.yaml
@@ -222,8 +222,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve Required SwiftPM Packages
         continue-on-error: true

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,11 @@
-// swift-tools-version:6.0
+
+// swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import Foundation
 import PackageDescription
 
-let strictConcurrencyFlags: [SwiftSetting] = []
+let strictConcurrencyFlags: [SwiftSetting] = [.swiftLanguageMode(.v5)]
 // [.enableExperimentalFeature("StrictConcurrency"), .enableUpcomingFeature("InferSendableFromCaptures")]
 
 let env = ProcessInfo.processInfo.environment
@@ -295,7 +296,8 @@ let package = Package(
             ),
             T.target(
                 name: "FishyJoesConfig",
-                resources: [.copy("tool-versions.json")]
+                resources: [.copy("tool-versions.json")],
+                swiftSettings: strictConcurrencyFlags
             ),
             T.target(
                 name: "FishyJoesExecute",

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import Foundation

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.2
+// swift-tools-version:6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import Foundation

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,3 @@
-
 // swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 

--- a/Sources/FishyJoesConfig/tool-versions.json
+++ b/Sources/FishyJoesConfig/tool-versions.json
@@ -1,9 +1,9 @@
 {
   "swiftWasm": {
     "//": "values taken from https://github.com/swiftwasm/swift/releases",
-    "toolchain": "6.3-snapshot-2026-01-16",
-    "sdk": "6.3-SNAPSHOT-2026-01-16-a",
-    "sdkChecksum": "2fbc3577e2f360eb61f27f42247de6971e6193dd4a2c9373e2d3dd00ff8af9ef",
+    "toolchain": "6.3-snapshot-2026-02-21",
+    "sdk": "6.3-SNAPSHOT-2026-02-21-a",
+    "sdkChecksum": "793972161e875b131350dd0f14cb0f2bf887d720102114e5485cf1e9512bc154",
     "targets": [
       {
         "triple": "wasm32-unknown-wasip1"

--- a/Sources/FishyJoesConfig/tool-versions.json
+++ b/Sources/FishyJoesConfig/tool-versions.json
@@ -1,12 +1,12 @@
 {
   "swiftWasm": {
     "//": "values taken from https://github.com/swiftwasm/swift/releases",
-    "toolchain": "6.1",
-    "sdk": "6.1-RELEASE",
-    "sdkChecksum": "7550b4c77a55f4b637c376f5d192f297fe185607003a6212ad608276928db992",
+    "toolchain": "6.3-snapshot-2026-01-16",
+    "sdk": "6.3-SNAPSHOT-2026-01-16-a",
+    "sdkChecksum": "2fbc3577e2f360eb61f27f42247de6971e6193dd4a2c9373e2d3dd00ff8af9ef",
     "targets": [
       {
-        "triple": "wasm32-unknown-wasi"
+        "triple": "wasm32-unknown-wasip1"
       }
     ]
   },

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -246,7 +246,6 @@ extension CodeGen {
                 }
             }
 
-
             fragment.output(#"// swift-tools-version:6.2"#)
             fragment.output(#"// BEGIN GENERATED CODE"#)
             fragment.blankLine()

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -246,7 +246,8 @@ extension CodeGen {
                 }
             }
 
-            fragment.output(#"// swift-tools-version:6.0"#)
+
+            fragment.output(#"// swift-tools-version:6.2"#)
             fragment.output(#"// BEGIN GENERATED CODE"#)
             fragment.blankLine()
 
@@ -254,7 +255,7 @@ extension CodeGen {
             fragment.output(#"import Foundation"#)
             fragment.blankLine()
 
-            fragment.output(#"let strictConcurrencyFlags: [SwiftSetting] = []"#)
+            fragment.output(#"let strictConcurrencyFlags: [SwiftSetting] = [.swiftLanguageMode(.v5)]"#)
             fragment.output(#"// [.enableExperimentalFeature("StrictConcurrency"), .enableUpcomingFeature("InferSendableFromCaptures")]"#)
             fragment.blankLine()
 

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -246,7 +246,7 @@ extension CodeGen {
                 }
             }
 
-            fragment.output(#"// swift-tools-version:6.1"#)
+            fragment.output(#"// swift-tools-version:6.2"#)
             fragment.output(#"// BEGIN GENERATED CODE"#)
             fragment.blankLine()
 

--- a/Sources/FishyJoesExecute/CodeGen.swift
+++ b/Sources/FishyJoesExecute/CodeGen.swift
@@ -246,7 +246,7 @@ extension CodeGen {
                 }
             }
 
-            fragment.output(#"// swift-tools-version:6.2"#)
+            fragment.output(#"// swift-tools-version:6.1"#)
             fragment.output(#"// BEGIN GENERATED CODE"#)
             fragment.blankLine()
 
@@ -349,7 +349,7 @@ extension CodeGen {
                             fragment.output(#"name: "\#(config.module)_WasmMainShim","#)
                             fragment.output(#"dependencies: [.target(name: "\#(config.module)_NodeInterface")],"#)
                             fragment.output(#"path: "Sources/WasmMainShim","#)
-                            fragment.output(#"swiftSettings: [.unsafeFlags(["-warn-concurrency"])] + strictConcurrencyFlags"#)
+                            fragment.output(#"swiftSettings: strictConcurrencyFlags"#)
                         }
                     }
                     fragment.outputBlock(#" : ["#) {

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-c-sharp.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-c-sharp.yaml
@@ -187,8 +187,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
@@ -168,8 +168,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-kotlin.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-kotlin.yaml
@@ -178,8 +178,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-typescript.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-typescript.yaml
@@ -217,8 +217,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true

--- a/Sources/FishyJoesNodeRuntime/JavaScriptEventLoop.swift
+++ b/Sources/FishyJoesNodeRuntime/JavaScriptEventLoop.swift
@@ -91,44 +91,47 @@ public final class JavaScriptEventLoop: SerialExecutor, @unchecked Sendable {
 
     private static var didInstallGlobalExecutor = false
 
-    /// Set JavaScript event loop based executor to be the global executor
-    /// Note that this should be called before any of the jobs are created.
-    /// This installation step will be unnecessary after custom executor are
-    /// introduced officially. See also [a draft proposal for custom
-    /// executors](https://github.com/rjmccall/swift-evolution/blob/custom-executors/proposals/0000-custom-executors.md#the-default-global-concurrent-executor)
+    /// Install ExecutorFactory and delay hooks for Swift 6.3 concurrency integration.
+    ///
+    /// Sets the JavaScript event loop as the global executor. This must be called before any async jobs are created.
+    ///
+    /// The ExecutorFactory API handles immediate job enqueueing, while delay hooks are still needed
+    /// for Task.sleep and other time-based scheduling operations.
     public static func installGlobalExecutor(env: NAPI.Env) throws {
         guard !didInstallGlobalExecutor else { return }
 
         try setupShared(env: env)
 
-        typealias swift_task_enqueueGlobal_hook_Fn = @convention(thin) (UnownedJob, swift_task_enqueueGlobal_original) -> Void
-        let swift_task_enqueueGlobal_hook_impl: swift_task_enqueueGlobal_hook_Fn = { job, _ in
-            JavaScriptEventLoop.shared.enqueue(job)
-        }
-        swift_task_enqueueGlobal_hook = unsafeBitCast(swift_task_enqueueGlobal_hook_impl, to: UnsafeMutableRawPointer?.self)
+        _Concurrency._createExecutors(factory: JavaScriptEventLoop.self)
+        installDelayHooks()
 
+        didInstallGlobalExecutor = true
+    }
+
+    /// Install delay-related hooks for time-based async operations.
+    ///
+    /// The ExecutorFactory handles immediate job enqueueing, but delay hooks are still needed
+    /// for Task.sleep and other time-based scheduling operations.
+    private static func installDelayHooks() {
         typealias swift_task_enqueueGlobalWithDelay_hook_Fn = @convention(thin) (UInt64, UnownedJob, swift_task_enqueueGlobalWithDelay_original) -> Void
         let swift_task_enqueueGlobalWithDelay_hook_impl: swift_task_enqueueGlobalWithDelay_hook_Fn = { delay, job, _ in
             JavaScriptEventLoop.shared.enqueue(job, withDelay: delay)
         }
-        swift_task_enqueueGlobalWithDelay_hook = unsafeBitCast(swift_task_enqueueGlobalWithDelay_hook_impl, to: UnsafeMutableRawPointer?.self)
+        swift_task_enqueueGlobalWithDelay_hook = unsafeBitCast(
+            swift_task_enqueueGlobalWithDelay_hook_impl,
+            to: UnsafeMutableRawPointer?.self
+        )
 
         #if os(WASI)
-        // This doesn't work with Xcode 14.0 so it always requires WASI
         typealias swift_task_enqueueGlobalWithDeadline_hook_Fn = @convention(thin) (Int64, Int64, Int64, Int64, Int32, UnownedJob, swift_task_enqueueGlobalWithDelay_original) -> Void
         let swift_task_enqueueGlobalWithDeadline_hook_impl: swift_task_enqueueGlobalWithDeadline_hook_Fn = { sec, nsec, tsec, tnsec, clock, job, _ in
             JavaScriptEventLoop.shared.enqueue(job, withDelay: sec, nsec, tsec, tnsec, clock)
         }
-        swift_task_enqueueGlobalWithDeadline_hook = unsafeBitCast(swift_task_enqueueGlobalWithDeadline_hook_impl, to: UnsafeMutableRawPointer?.self)
+        swift_task_enqueueGlobalWithDeadline_hook = unsafeBitCast(
+            swift_task_enqueueGlobalWithDeadline_hook_impl,
+            to: UnsafeMutableRawPointer?.self
+        )
         #endif
-
-        typealias swift_task_enqueueMainExecutor_hook_Fn = @convention(thin) (UnownedJob, swift_task_enqueueMainExecutor_original) -> Void
-        let swift_task_enqueueMainExecutor_hook_impl: swift_task_enqueueMainExecutor_hook_Fn = { job, _ in
-            JavaScriptEventLoop.shared.enqueue(job)
-        }
-        swift_task_enqueueMainExecutor_hook = unsafeBitCast(swift_task_enqueueMainExecutor_hook_impl, to: UnsafeMutableRawPointer?.self)
-
-        didInstallGlobalExecutor = true
     }
 
     static func setupShared(env: NAPI.Env) throws {
@@ -227,6 +230,43 @@ extension JavaScriptEventLoop {
         swift_get_time(&nowSec, &nowNSec, clock)
         let delayNanosec = (seconds - nowSec) * 1_000_000_000 + (nanoseconds - nowNSec)
         enqueue(job, withDelay: delayNanosec <= 0 ? 0 : UInt64(delayNanosec))
+    }
+}
+
+// MARK: - ExecutorFactory Support
+
+extension JavaScriptEventLoop: ExecutorFactory {
+    /// Bridges Swift concurrency to the JavaScript event loop by delegating all jobs to JavaScriptEventLoop.shared.
+    final class EventLoopExecutor: TaskExecutor, MainExecutor, SerialExecutor {
+        static let shared = EventLoopExecutor()
+
+        private init() {}
+
+        func checkIsolated() {}
+
+        func enqueue(_ job: consuming ExecutorJob) {
+            JavaScriptEventLoop.shared.enqueue(UnownedJob(job))
+        }
+
+        func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+            UnownedSerialExecutor(ordinary: self)
+        }
+
+        func run() throws {
+            // No-op for JavaScript event loop - JavaScript controls the run loop
+        }
+
+        func stop() {
+            // No-op for JavaScript event loop
+        }
+    }
+
+    public static var mainExecutor: any MainExecutor {
+        EventLoopExecutor.shared
+    }
+
+    public static var defaultExecutor: any TaskExecutor {
+        EventLoopExecutor.shared
     }
 }
 

--- a/Sources/FishyJoesNodeRuntime/JavaScriptEventLoop.swift
+++ b/Sources/FishyJoesNodeRuntime/JavaScriptEventLoop.swift
@@ -30,8 +30,8 @@
 
 #if os(WASI)
 
-import NodeAPI
 @_spi(ExperimentalCustomExecutors) import _Concurrency
+import NodeAPI
 
 // NOTE: `@available` annotations are semantically wrong, but they make it easier to develop applications targeting WebAssembly in Xcode.
 

--- a/Sources/FishyJoesNodeRuntime/JavaScriptEventLoop.swift
+++ b/Sources/FishyJoesNodeRuntime/JavaScriptEventLoop.swift
@@ -242,7 +242,9 @@ extension JavaScriptEventLoop: ExecutorFactory {
 
         private init() {}
 
-        func checkIsolated() {}
+        func checkIsolated() {
+            // No-op: JavaScript is single-threaded, so isolation is always satisfied
+        }
 
         func enqueue(_ job: consuming ExecutorJob) {
             JavaScriptEventLoop.shared.enqueue(UnownedJob(job))

--- a/Sources/FishyJoesNodeRuntime/JavaScriptEventLoop.swift
+++ b/Sources/FishyJoesNodeRuntime/JavaScriptEventLoop.swift
@@ -31,6 +31,7 @@
 #if os(WASI)
 
 import NodeAPI
+@_spi(ExperimentalCustomExecutors) import _Concurrency
 
 // NOTE: `@available` annotations are semantically wrong, but they make it easier to develop applications targeting WebAssembly in Xcode.
 
@@ -235,6 +236,7 @@ extension JavaScriptEventLoop {
 
 // MARK: - ExecutorFactory Support
 
+@_spi(ExperimentalCustomExecutors)
 extension JavaScriptEventLoop: ExecutorFactory {
     /// Bridges Swift concurrency to the JavaScript event loop by delegating all jobs to JavaScriptEventLoop.shared.
     final class EventLoopExecutor: TaskExecutor, MainExecutor, SerialExecutor {

--- a/Tests/NAPITests/NAPITests.swift
+++ b/Tests/NAPITests/NAPITests.swift
@@ -22,8 +22,8 @@ class NAPITests: XCTestCase {
             "swift",
             arguments: [
                 "sdk", "configure",
-                "\(ToolVersions.shared.swiftWasm.sdk)-wasm32-unknown-wasi",
-                "wasm32-unknown-wasi",
+                "\(ToolVersions.shared.swiftWasm.sdk)-wasm32-unknown-wasip1",
+                "wasm32-unknown-wasip1",
                 "--show-configuration",
             ]
         ).runLines()
@@ -41,12 +41,12 @@ class NAPITests: XCTestCase {
     lazy var CC = "clang"
     lazy var LD = "clang"
     lazy var CFLAGS: [String] = [
-        "-target", "wasm32-unknown-wasi",
+        "-target", "wasm32-unknown-wasip1",
         "--sysroot", wasiSDKPath,
         "-ISources/NodeAPI/include",
     ]
     lazy var LDFLAGS: [String] = [
-        "-target", "wasm32-unknown-wasi",
+        "-target", "wasm32-unknown-wasip1",
         "-resource-dir", "\(wasiSDKPath)/../swift.xctoolchain/usr/lib/swift_static/clang",
         "--sysroot", wasiSDKPath,
 

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-c-sharp.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-c-sharp.yaml
@@ -189,8 +189,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
@@ -170,8 +170,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-kotlin.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-kotlin.yaml
@@ -180,8 +180,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-typescript.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-typescript.yaml
@@ -219,8 +219,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true

--- a/integration-tests/TestAPI/bindings/swift-interfaces/generated/TestAPI-bindings/Package.swift
+++ b/integration-tests/TestAPI/bindings/swift-interfaces/generated/TestAPI-bindings/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 // BEGIN GENERATED CODE
 
 import PackageDescription
 import Foundation
 
-let strictConcurrencyFlags: [SwiftSetting] = []
+let strictConcurrencyFlags: [SwiftSetting] = [.swiftLanguageMode(.v5)]
 // [.enableExperimentalFeature("StrictConcurrency"), .enableUpcomingFeature("InferSendableFromCaptures")]
 
 let env = ProcessInfo.processInfo.environment

--- a/integration-tests/TestAPI/bindings/swift-interfaces/generated/TestAPI-bindings/Package.swift
+++ b/integration-tests/TestAPI/bindings/swift-interfaces/generated/TestAPI-bindings/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.2
+// swift-tools-version:6.1
 // BEGIN GENERATED CODE
 
 import PackageDescription
@@ -82,7 +82,7 @@ var package = Package(
                 name: "TestAPI_WasmMainShim",
                 dependencies: [.target(name: "TestAPI_NodeInterface")],
                 path: "Sources/WasmMainShim",
-                swiftSettings: [.unsafeFlags(["-warn-concurrency"])] + strictConcurrencyFlags
+                swiftSettings: strictConcurrencyFlags
             ),
         ] : [
             .target(

--- a/integration-tests/TestAPI/bindings/swift-interfaces/generated/TestAPI-bindings/Package.swift
+++ b/integration-tests/TestAPI/bindings/swift-interfaces/generated/TestAPI-bindings/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.2
 // BEGIN GENERATED CODE
 
 import PackageDescription

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-c-sharp.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-c-sharp.yaml
@@ -189,8 +189,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-dart.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-dart.yaml
@@ -170,8 +170,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-kotlin.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-kotlin.yaml
@@ -180,8 +180,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-typescript.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-typescript.yaml
@@ -219,8 +219,8 @@ jobs:
 
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1-release
-          tag: 6.1-RELEASE
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
 
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true


### PR DESCRIPTION
Migrate FishyJoes to Swift 6.3 WASM with proper ExecutorFactory API integration. This update removes all previous WASM compilation workarounds that were needed due to Swift 6.1/6.2 compiler bugs.

# Changes
- Update toolchain to Swift 6.3 snapshot (2026-01-16)
- Update WASM SDK to 6.3-SNAPSHOT-2026-01-16-a
- Change triple from wasm32-unknown-wasi to wasm32-unknown-wasip1
- Implement ExecutorFactory API for Swift 6.3+ concurrency
- Use dynamic triple in NAPITests for better maintainability
 
# Toolchain Updates
- **Swift WASM toolchain:** `6.1` → `6.3-snapshot-2026-01-16`
- **WASM SDK:** `6.1-RELEASE` → `6.3-SNAPSHOT-2026-01-16-a`
- **Target triple:** `wasm32-unknown-wasi` → `wasm32-unknown-wasip1`

# ExecutorFactory Implementation
- Implemented Swift 6.3+ `ExecutorFactory` API for proper concurrency runtime integration
