### PR TITLE
Enable flexible version support for Gradle using Maven-style ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Without `--flexible-versions`:
 With `--flexible-versions`:
 - NuGet: `[2.19.4,3.0.0)` for upToNextMajor constraints
 - NPM/Dart: `^2.19.4` for upToNextMajor, `~1.2.3` for upToNextMinor
-- Gradle: `2.19.4` (always exact)
+- Gradle: `[2.19.4,3.0.0)` for upToNextMajor, `[1.2.3,1.3.0)` for upToNextMinor
 
 Example:
 ```

--- a/Sources/FishyJoesExecute/SwiftPackage.swift
+++ b/Sources/FishyJoesExecute/SwiftPackage.swift
@@ -104,12 +104,9 @@ extension SwiftPackage.Dependency {
     }
 
     func versionInGradleFormat(flexibleVersions: Bool = false) -> String {
-        // The flexibleVersions parameter is intentionally unused for Gradle.
-        // Gradle's version constraint solver has limitations with complex range constraints
-        // (see https://github.com/gradle/gradle/issues/8126). For consistency and reliability
-        // across build environments, we always use exact versions for Gradle, regardless of the flag.
-        // As a temporary solution for Android, the cri-next-major-resolver plugin
-        // (https://github.com/cricut/cri-next-major-resolver) can be used to resolve version constraints.
+        // Gradle version range format using Maven-style syntax.
+        // When flexibleVersions is true, generates inclusive-exclusive ranges: [min,max)
+        // Syntax: '[' = inclusive, ')' = exclusive, '(' = exclusive, ']' = inclusive
         let spec: String
         switch self {
         case .sourceControl(_, _, .branch(let name)):
@@ -117,11 +114,23 @@ extension SwiftPackage.Dependency {
         case .sourceControl(_, _, .revision(let name)):
             spec = name
         case .sourceControl(_, _, .upToNextMajor(let baseVersion)):
-            spec = baseVersion.versionString
+            if flexibleVersions {
+                spec = "[\(baseVersion),\(baseVersion.nextMajor))"
+            } else {
+                spec = baseVersion.versionString
+            }
         case .sourceControl(_, _, .upToNextMinor(let baseVersion)):
-            spec = baseVersion.versionString
-        case .sourceControl(_, _, .range(let lowerBound, _)):
-            spec = lowerBound.versionString
+            if flexibleVersions {
+                spec = "[\(baseVersion),\(baseVersion.nextMinor))"
+            } else {
+                spec = baseVersion.versionString
+            }
+        case .sourceControl(_, _, .range(let lowerBound, let upperBound)):
+            if flexibleVersions {
+                spec = "[\(lowerBound),\(upperBound))"
+            } else {
+                spec = lowerBound.versionString
+            }
         case .sourceControl(_, _, .exact(let version)):
             spec = version.versionString
         case .fileSystem:

--- a/Tests/FishyJoesExecuteTests/SwiftPackageVersionFormatTests.swift
+++ b/Tests/FishyJoesExecuteTests/SwiftPackageVersionFormatTests.swift
@@ -125,8 +125,39 @@ class SwiftPackageVersionFormatTests: XCTestCase {
             location: testURL,
             requirement: .upToNextMajor(baseVersion: SemanticVersion(major: 2, minor: 19, patch: 4))
         )
+        let upToNextMinor = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .upToNextMinor(baseVersion: SemanticVersion(major: 1, minor: 2, patch: 3))
+        )
+        let exact = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .exact(version: SemanticVersion(major: 1, minor: 11, patch: 11))
+        )
+        let revision = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .revision(name: "abc123")
+        )
+        let range = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .range(
+                lowerBound: SemanticVersion(major: 1, minor: 0, patch: 0),
+                upperBound: SemanticVersion(major: 2, minor: 0, patch: 0)
+            )
+        )
 
         XCTAssertEqual(upToNextMajor.versionInGradleFormat(flexibleVersions: false), "2.19.4")
-        XCTAssertEqual(upToNextMajor.versionInGradleFormat(flexibleVersions: true), "2.19.4")
+        XCTAssertEqual(upToNextMajor.versionInGradleFormat(flexibleVersions: true), "[2.19.4,3.0.0)")
+        XCTAssertEqual(upToNextMinor.versionInGradleFormat(flexibleVersions: false), "1.2.3")
+        XCTAssertEqual(upToNextMinor.versionInGradleFormat(flexibleVersions: true), "[1.2.3,1.3.0)")
+        XCTAssertEqual(exact.versionInGradleFormat(flexibleVersions: false), "1.11.11")
+        XCTAssertEqual(exact.versionInGradleFormat(flexibleVersions: true), "1.11.11")
+        XCTAssertEqual(revision.versionInGradleFormat(flexibleVersions: false), "abc123")
+        XCTAssertEqual(revision.versionInGradleFormat(flexibleVersions: true), "abc123")
+        XCTAssertEqual(range.versionInGradleFormat(flexibleVersions: false), "1.0.0")
+        XCTAssertEqual(range.versionInGradleFormat(flexibleVersions: true), "[1.0.0,2.0.0)")
     }
 }


### PR DESCRIPTION
## Summary
Enable flexibleVersions support for Gradle projects using Maven-style version ranges, aligning Gradle with npm, Dart, and NuGet behavior.

## Changes
- Implement Maven-style range syntax [min,max) in versionInGradleFormat() when flexibleVersions: true
- Add test coverage
- Update README documentation to reflect new Gradle behavior

## Version Format Mapping
| SPM Constraint | flexibleVersions: false | flexibleVersions: true |
|----------------|---------------------------|--------------------------|
| .upToNextMajor(2.19.4) | 2.19.4 | [2.19.4,3.0.0) |
| .upToNextMinor(1.2.3) | 1.2.3 | [1.2.3,1.3.0) |
| .range(1.0.0, 2.0.0) | 1.0.0 | [1.0.0,2.0.0) |
| .exact, .revision, .branch | unchanged | unchanged |

## Notes
- Backward compatible: default behavior (flexibleVersions: false) unchanged
- Removes outdated reference to gradle/gradle#8126 (2018 issue, since resolved)
- Maven-style ranges are standard Gradle feature supported since v1.0