### PR TITLE
feat: add SPM caching, fix Windows resolve retry, pin action hashes

### DIFF
--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-c-sharp.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-c-sharp.yaml
@@ -33,7 +33,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
@@ -111,7 +111,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
@@ -194,7 +194,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
@@ -288,7 +288,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-c-sharp.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-c-sharp.yaml
@@ -37,6 +37,17 @@ jobs:
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            .build/workspace-state.json
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
@@ -103,6 +114,17 @@ jobs:
         uses: de-vri-es/setup-git-credentials@v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
+
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            .build/workspace-state.json
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
@@ -190,14 +212,31 @@ jobs:
           branch: swift-6.1-release
           tag: 6.1-RELEASE
 
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            .build/workspace-state.json
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true
         shell: pwsh
         run: |
           $ErrorActionPreference = 'SilentlyContinue'
-          swift package resolve
-          swift package resolve
-          swift package resolve
+          $maxRetries = 3
+          for ($i = 1; $i -le $maxRetries; $i++) {
+              swift package resolve
+              if ($LASTEXITCODE -eq 0) { break }
+              if ($i -lt $maxRetries) {
+                  Write-Host "Resolve attempt $i failed, retrying in 5s..."
+                  Start-Sleep -Seconds 5
+              }
+          }
           echo SWIFT_WINDOWS_BASH=".build/checkouts/FishyJoes/scripts/swift-shim.ps1" >> $env:GITHUB_ENV
 
       - name: Setup node

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
@@ -33,7 +33,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
@@ -104,7 +104,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup Git Credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
@@ -182,7 +182,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
@@ -271,7 +271,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
@@ -37,6 +37,17 @@ jobs:
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            .build/workspace-state.json
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - uses: dart-lang/setup-dart@v1
 
       - name: Install generation tools
@@ -96,6 +107,17 @@ jobs:
         uses: de-vri-es/setup-git-credentials@v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
+
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            .build/workspace-state.json
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
       - uses: dart-lang/setup-dart@v1
 
@@ -171,14 +193,31 @@ jobs:
           branch: swift-6.1-release
           tag: 6.1-RELEASE
 
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            .build/workspace-state.json
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true
         shell: pwsh
         run: |
           $ErrorActionPreference = 'SilentlyContinue'
-          swift package resolve
-          swift package resolve
-          swift package resolve
+          $maxRetries = 3
+          for ($i = 1; $i -le $maxRetries; $i++) {
+              swift package resolve
+              if ($LASTEXITCODE -eq 0) { break }
+              if ($i -lt $maxRetries) {
+                  Write-Host "Resolve attempt $i failed, retrying in 5s..."
+                  Start-Sleep -Seconds 5
+              }
+          }
           echo SWIFT_WINDOWS_BASH=".build/checkouts/FishyJoes/scripts/swift-shim.ps1" >> $env:GITHUB_ENV
 
       - name: Setup node

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-kotlin.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-kotlin.yaml
@@ -35,7 +35,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
@@ -111,7 +111,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
@@ -194,7 +194,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
@@ -288,7 +288,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-kotlin.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-kotlin.yaml
@@ -39,6 +39,17 @@ jobs:
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            .build/workspace-state.json
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Setup JDK
         uses: actions/setup-java@v3
         with:
@@ -103,6 +114,17 @@ jobs:
         uses: de-vri-es/setup-git-credentials@v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
+
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            .build/workspace-state.json
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
       - name: Setup JDK
         uses: actions/setup-java@v3
@@ -181,14 +203,31 @@ jobs:
           branch: swift-6.1-release
           tag: 6.1-RELEASE
 
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            .build/workspace-state.json
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true
         shell: pwsh
         run: |
           $ErrorActionPreference = 'SilentlyContinue'
-          swift package resolve
-          swift package resolve
-          swift package resolve
+          $maxRetries = 3
+          for ($i = 1; $i -le $maxRetries; $i++) {
+              swift package resolve
+              if ($LASTEXITCODE -eq 0) { break }
+              if ($i -lt $maxRetries) {
+                  Write-Host "Resolve attempt $i failed, retrying in 5s..."
+                  Start-Sleep -Seconds 5
+              }
+          }
           echo SWIFT_WINDOWS_BASH=".build/checkouts/FishyJoes/scripts/swift-shim.ps1" >> $env:GITHUB_ENV
 
       # NOTE: don't delete this. Even if it looks unused, some downsteam pre-build hooks rely on it.

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-regenerate-check.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-regenerate-check.yaml
@@ -28,7 +28,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-typescript.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-typescript.yaml
@@ -38,6 +38,17 @@ jobs:
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            .build/workspace-state.json
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Install generation tools
         shell: zsh {0}
         run: |
@@ -118,6 +129,17 @@ jobs:
         uses: de-vri-es/setup-git-credentials@v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
+
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            .build/workspace-state.json
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -220,14 +242,31 @@ jobs:
           branch: swift-6.1-release
           tag: 6.1-RELEASE
 
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            .build/workspace-state.json
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Pre-resolve required swiftpm packages & fetch fishyjoes scripts
         continue-on-error: true
         shell: pwsh
         run: |
           $ErrorActionPreference = 'SilentlyContinue'
-          swift package resolve
-          swift package resolve
-          swift package resolve
+          $maxRetries = 3
+          for ($i = 1; $i -le $maxRetries; $i++) {
+              swift package resolve
+              if ($LASTEXITCODE -eq 0) { break }
+              if ($i -lt $maxRetries) {
+                  Write-Host "Resolve attempt $i failed, retrying in 5s..."
+                  Start-Sleep -Seconds 5
+              }
+          }
           echo SWIFT_WINDOWS_BASH=".build/checkouts/FishyJoes/scripts/swift-shim.ps1" >> $env:GITHUB_ENV
 
       - name: Pre-build hook

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-typescript.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-typescript.yaml
@@ -34,7 +34,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
@@ -126,7 +126,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 
@@ -226,7 +226,7 @@ jobs:
           token: ${{ secrets.CRICUT_GPR_TOKEN }}
 
       - name: Setup git credentials
-        uses: de-vri-es/setup-git-credentials@v2
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2
         with:
           credentials: https://cricut-builduser:${{ secrets.CRICUT_GPR_TOKEN }}@github.com/
 


### PR DESCRIPTION
## Summary
- Add `actions/cache@v4` for SPM dependencies (`.build/checkouts`, `.build/repositories`, `.build/workspace-state.json`) to all platform jobs (macOS, Linux, Windows) across all 4 binding workflow templates
- Replace 3x sequential `swift package resolve` on Windows with a retry loop that breaks on first success and waits 5s between retries
- Pin `de-vri-es/setup-git-credentials` to exact commit hash `5e1f18da68b7039c7f824408d170811aaec93ca8` for supply chain security

## Expected impact
- **Windows**: ~5-15 min savings per binding workflow (cache hit + retry stops early)
- **Ubuntu**: ~2-5 min savings per workflow
- **macOS**: ~1-2 min savings

## Test plan
- [ ] First CI run: cache miss, all jobs should work identically to current behavior
- [ ] Second CI run: cache hit visible in "Cache SPM dependencies" step logs, faster resolve
- [ ] Windows retry loop logs "Resolve attempt N failed" only on actual failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)