### PR TITLE
Dart 3.9+ tag_pattern

### DIFF
--- a/.github/workflows/iota-runtime.yaml
+++ b/.github/workflows/iota-runtime.yaml
@@ -190,15 +190,68 @@ jobs:
 
       - name: Determine version
         shell: zsh {0}
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euxo pipefail
 
-          VERSION=${GITHUB_REF#refs/*/}
-          if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)*$ ]]; then
+          SEMVER_REGEX='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+              VERSION="$RELEASE_TAG"
+          else
+              VERSION=${GITHUB_REF#refs/*/}
+          fi
+
+          if [[ ! $VERSION =~ $SEMVER_REGEX ]]; then
+            if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+              echo "Unsupported release tag '$VERSION'" >&2
+              exit 1
+            fi
+
               VERSION="0.0.1-$(git rev-parse --short HEAD)"
           fi
+
           echo "Detected Version is '$VERSION'"
-          echo VERSION=$VERSION >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "PUBLISH_TAG=$VERSION-dart-publish" >> $GITHUB_ENV
+
+      - name: Prepare Dart publish tag
+        if: github.event_name == 'release'
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+
+          yq -i '.version = strenv(VERSION)' dart-runtime/pubspec.yaml
+
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR_ID+$GITHUB_ACTOR@users.noreply.github.com"
+          git add dart-runtime/pubspec.yaml
+
+          if git diff --cached --quiet; then
+              echo "dart-runtime/pubspec.yaml already has version '$VERSION'"
+          else
+              git commit -m "chore: prepare Dart publish tag for $VERSION"
+          fi
+
+          git tag "$PUBLISH_TAG"
+          git show --stat --oneline --decorate HEAD
+          git rev-parse "$PUBLISH_TAG"
+
+          echo "Publish tag '$PUBLISH_TAG' prepared locally"
+
+      - name: Push Dart publish tag
+        if: github.event_name == 'release'
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$PUBLISH_TAG" >/dev/null 2>&1; then
+              echo "Publish tag '$PUBLISH_TAG' already exists"
+              exit 0
+          fi
+
+          git push origin "refs/tags/$PUBLISH_TAG"
 
       - name: Pack
         shell: zsh {0}

--- a/Sources/FishyJoesExecute/Phases/DartPhases.swift
+++ b/Sources/FishyJoesExecute/Phases/DartPhases.swift
@@ -28,8 +28,16 @@ class DartPhases: IotaPhases, Phases {
                     "  path: DEPENDENCY_NOT_FOUND",
                 ]
             }
-            // Always use exact version for git ref: git does not support semver range syntax.
-            // Flexible versions for Dart are expressed via flutter-package.json (npm), not pubspec.yaml.
+            if options.config.flexibleVersions,
+               let tagPattern = dependency.tagPatternAndVersionConstraint() {
+                return lines + [
+                    #"  git:"#,
+                    #"    url: "https://github.com/cricut/\#(depNames.swift).git""#,
+                    #"    tag_pattern: "\#(tagPattern.tagPattern)""#,
+                    #"    path: "\#(depNames.path)""#,
+                    #"  version: "\#(tagPattern.versionConstraint)""#,
+                ]
+            }
             if let version = dependency.versionInPubspecFormat(flexibleVersions: false) {
                 return lines + [
                     #"  git:"#,

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
@@ -193,6 +193,9 @@ jobs:
       - build-test-dart-mac
       - build-test-dart-linux
       - build-test-dart-windows
+    permissions:
+      contents: write
+      packages: write
     steps:
       - __CI_GIT_STEPS__
 
@@ -225,15 +228,68 @@ jobs:
 
       - name: Determine version
         shell: zsh {0}
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euxo pipefail
 
-          VERSION=${GITHUB_REF#refs/*/}
-          if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)*$ ]]; then
+          SEMVER_REGEX='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+              VERSION="$RELEASE_TAG"
+          else
+              VERSION=${GITHUB_REF#refs/*/}
+          fi
+
+          if [[ ! $VERSION =~ $SEMVER_REGEX ]]; then
+            if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+              echo "Unsupported release tag '$VERSION'" >&2
+              exit 1
+            fi
+
               VERSION="0.0.1-$(git rev-parse --short HEAD)"
           fi
+
           echo "Detected Version is '$VERSION'"
-          echo VERSION=$VERSION >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "PUBLISH_TAG=$VERSION-dart-publish" >> $GITHUB_ENV
+
+      - name: Prepare Dart publish tag
+        if: github.event_name == 'release'
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+
+          yq -i '.version = strenv(VERSION)' bindings/dart/generated/pubspec.yaml
+
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR_ID+$GITHUB_ACTOR@users.noreply.github.com"
+          git add bindings/dart/generated/pubspec.yaml
+
+          if git diff --cached --quiet; then
+              echo "bindings/dart/generated/pubspec.yaml already has version '$VERSION'"
+          else
+              git commit -m "chore: prepare Dart publish tag for $VERSION"
+          fi
+
+          git tag "$PUBLISH_TAG"
+          git show --stat --oneline --decorate HEAD
+          git rev-parse "$PUBLISH_TAG"
+
+          echo "Publish tag '$PUBLISH_TAG' prepared locally"
+
+      - name: Push Dart publish tag
+        if: github.event_name == 'release'
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$PUBLISH_TAG" >/dev/null 2>&1; then
+              echo "Publish tag '$PUBLISH_TAG' already exists"
+              exit 0
+          fi
+
+          git push origin "refs/tags/$PUBLISH_TAG"
 
       - name: Pack
         shell: zsh {0}

--- a/Sources/FishyJoesExecute/SwiftPackage.swift
+++ b/Sources/FishyJoesExecute/SwiftPackage.swift
@@ -280,6 +280,22 @@ extension SwiftPackage.Dependency {
             return nil
         }
     }
+
+    /// Returns the Dart 3.9+ `tag_pattern` + `version:` pair for a git dependency,
+    /// or nil when the requirement can't be expressed as a semver constraint
+    /// (branch/revision refs and local filesystem paths).
+    func tagPatternAndVersionConstraint() -> (tagPattern: String, versionConstraint: String)? {
+        switch self {
+        case .sourceControl(_, _, .branch), .sourceControl(_, _, .revision), .fileSystem:
+            return nil
+        case .sourceControl(_, _, .upToNextMajor),
+             .sourceControl(_, _, .upToNextMinor),
+             .sourceControl(_, _, .range),
+             .sourceControl(_, _, .exact):
+            guard let constraint = versionInPubspecFormat(flexibleVersions: true) else { return nil }
+            return (tagPattern: "{{version}}-dart-publish", versionConstraint: constraint)
+        }
+    }
 }
 
 extension SwiftPackage.Dependency.Requirement: Decodable {

--- a/Tests/FishyJoesExecuteTests/SwiftPackageVersionFormatTests.swift
+++ b/Tests/FishyJoesExecuteTests/SwiftPackageVersionFormatTests.swift
@@ -119,6 +119,56 @@ class SwiftPackageVersionFormatTests: XCTestCase {
         XCTAssertEqual(exact.versionInPubspecFormat(flexibleVersions: true), "1.11.11")
     }
 
+    func testTagPatternAndVersionConstraint() throws {
+        let upToNextMajor = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .upToNextMajor(baseVersion: SemanticVersion(major: 2, minor: 19, patch: 4))
+        )
+        let upToNextMajorZero = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .upToNextMajor(baseVersion: SemanticVersion(major: 0, minor: 5, patch: 0))
+        )
+        let upToNextMinor = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .upToNextMinor(baseVersion: SemanticVersion(major: 1, minor: 2, patch: 3))
+        )
+        let exact = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .exact(version: SemanticVersion(major: 1, minor: 11, patch: 11))
+        )
+        let range = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .range(
+                lowerBound: SemanticVersion(major: 1, minor: 0, patch: 0),
+                upperBound: SemanticVersion(major: 2, minor: 0, patch: 0)
+            )
+        )
+        let branch = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .branch(name: "main")
+        )
+        let revision = SwiftPackage.Dependency.sourceControl(
+            identity: "test",
+            location: testURL,
+            requirement: .revision(name: "abc123")
+        )
+
+        XCTAssertEqual(upToNextMajor.tagPatternAndVersionConstraint()?.tagPattern, "{{version}}-dart-publish")
+        XCTAssertEqual(upToNextMajor.tagPatternAndVersionConstraint()?.versionConstraint, "^2.19.4")
+        XCTAssertEqual(upToNextMajorZero.tagPatternAndVersionConstraint()?.versionConstraint, ">=0.5.0 <1.0.0")
+        XCTAssertEqual(upToNextMinor.tagPatternAndVersionConstraint()?.versionConstraint, "~1.2.3")
+        XCTAssertEqual(exact.tagPatternAndVersionConstraint()?.versionConstraint, "1.11.11")
+        XCTAssertEqual(range.tagPatternAndVersionConstraint()?.versionConstraint, ">=1.0.0 <2.0.0")
+        XCTAssertNil(branch.tagPatternAndVersionConstraint())
+        XCTAssertNil(revision.tagPatternAndVersionConstraint())
+    }
+
     func testVersionFormatGradle() throws {
         let upToNextMajor = SwiftPackage.Dependency.sourceControl(
             identity: "test",

--- a/dart-runtime/bin/setup.dart
+++ b/dart-runtime/bin/setup.dart
@@ -38,6 +38,22 @@ class Archive extends TarballSource {
   Archive(this.repoName, this.path, this.files, this.tarballName);
 }
 
+String releaseVersionForGitLock(String packageName, dynamic depLock) {
+  final description = depLock["description"];
+  final ref = description["ref"];
+  if (ref is String && ref.isNotEmpty) {
+    return ref;
+  }
+
+  final tagPattern = description["tag-pattern"];
+  final version = depLock["version"];
+  if (tagPattern is String && tagPattern.isNotEmpty && version is String && version.isNotEmpty) {
+    return version;
+  }
+
+  throw StateError("No release version found for $packageName in pubspec.lock");
+}
+
 void main() async {
   final pubDepsResult = await io.Process.run('dart', ['pub', 'deps', '--json']);
   io.stderr.write(pubDepsResult.stderr);
@@ -82,14 +98,14 @@ void main() async {
 
     if (source == 'git') {
       final url = Uri.parse(depLock["description"]["url"]);
-      String ref = depLock["description"]["ref"];
+      final version = releaseVersionForGitLock(name, depLock);
       final pathMatch = RegExp(r'cricut/(.*?)(.git)?$').firstMatch(url.path);
       if (pathMatch == null) {
         io.stderr.writeln("Couldn't determing github repo of $name");
         io.exit(1);
       }
       final repoName = pathMatch[1]!;
-      tarballSources.add(Download(repoName, ref, "$repoName-dart-binaries.tgz"));
+      tarballSources.add(Download(repoName, version, "$repoName-dart-binaries.tgz"));
     } else if (source == 'path') {
       final path = depLock["description"]["path"];
       final artifacts = ["macos/native", "linux/native", "windows/native"];

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
@@ -209,6 +209,9 @@ jobs:
       - build-test-dart-mac
       - build-test-dart-linux
       - build-test-dart-windows
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -244,15 +247,68 @@ jobs:
 
       - name: Determine version
         shell: zsh {0}
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euxo pipefail
 
-          VERSION=${GITHUB_REF#refs/*/}
-          if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)*$ ]]; then
+          SEMVER_REGEX='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+              VERSION="$RELEASE_TAG"
+          else
+              VERSION=${GITHUB_REF#refs/*/}
+          fi
+
+          if [[ ! $VERSION =~ $SEMVER_REGEX ]]; then
+            if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+              echo "Unsupported release tag '$VERSION'" >&2
+              exit 1
+            fi
+
               VERSION="0.0.1-$(git rev-parse --short HEAD)"
           fi
+
           echo "Detected Version is '$VERSION'"
-          echo VERSION=$VERSION >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "PUBLISH_TAG=$VERSION-dart-publish" >> $GITHUB_ENV
+
+      - name: Prepare Dart publish tag
+        if: github.event_name == 'release'
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+
+          yq -i '.version = strenv(VERSION)' bindings/dart/generated/pubspec.yaml
+
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR_ID+$GITHUB_ACTOR@users.noreply.github.com"
+          git add bindings/dart/generated/pubspec.yaml
+
+          if git diff --cached --quiet; then
+              echo "bindings/dart/generated/pubspec.yaml already has version '$VERSION'"
+          else
+              git commit -m "chore: prepare Dart publish tag for $VERSION"
+          fi
+
+          git tag "$PUBLISH_TAG"
+          git show --stat --oneline --decorate HEAD
+          git rev-parse "$PUBLISH_TAG"
+
+          echo "Publish tag '$PUBLISH_TAG' prepared locally"
+
+      - name: Push Dart publish tag
+        if: github.event_name == 'release'
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$PUBLISH_TAG" >/dev/null 2>&1; then
+              echo "Publish tag '$PUBLISH_TAG' already exists"
+              exit 0
+          fi
+
+          git push origin "refs/tags/$PUBLISH_TAG"
 
       - name: Pack
         shell: zsh {0}

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-dart.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-dart.yaml
@@ -209,6 +209,9 @@ jobs:
       - build-test-dart-mac
       - build-test-dart-linux
       - build-test-dart-windows
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -244,15 +247,68 @@ jobs:
 
       - name: Determine version
         shell: zsh {0}
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euxo pipefail
 
-          VERSION=${GITHUB_REF#refs/*/}
-          if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)*$ ]]; then
+          SEMVER_REGEX='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+              VERSION="$RELEASE_TAG"
+          else
+              VERSION=${GITHUB_REF#refs/*/}
+          fi
+
+          if [[ ! $VERSION =~ $SEMVER_REGEX ]]; then
+            if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+              echo "Unsupported release tag '$VERSION'" >&2
+              exit 1
+            fi
+
               VERSION="0.0.1-$(git rev-parse --short HEAD)"
           fi
+
           echo "Detected Version is '$VERSION'"
-          echo VERSION=$VERSION >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "PUBLISH_TAG=$VERSION-dart-publish" >> $GITHUB_ENV
+
+      - name: Prepare Dart publish tag
+        if: github.event_name == 'release'
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+
+          yq -i '.version = strenv(VERSION)' bindings/dart/generated/pubspec.yaml
+
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR_ID+$GITHUB_ACTOR@users.noreply.github.com"
+          git add bindings/dart/generated/pubspec.yaml
+
+          if git diff --cached --quiet; then
+              echo "bindings/dart/generated/pubspec.yaml already has version '$VERSION'"
+          else
+              git commit -m "chore: prepare Dart publish tag for $VERSION"
+          fi
+
+          git tag "$PUBLISH_TAG"
+          git show --stat --oneline --decorate HEAD
+          git rev-parse "$PUBLISH_TAG"
+
+          echo "Publish tag '$PUBLISH_TAG' prepared locally"
+
+      - name: Push Dart publish tag
+        if: github.event_name == 'release'
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$PUBLISH_TAG" >/dev/null 2>&1; then
+              echo "Publish tag '$PUBLISH_TAG' already exists"
+              exit 0
+          fi
+
+          git push origin "refs/tags/$PUBLISH_TAG"
 
       - name: Pack
         shell: zsh {0}


### PR DESCRIPTION
## Summary
Use publish-only `-dart-publish` tags to support Dart 3.9+ `tag_pattern` releases without mutating the main release tag or branch history.

## Why
Dart `tag_pattern` resolution requires the matched tagged commit to contain a matching `version:` in `pubspec.yaml`.

FishyJoes release tags do not guarantee that, because the Dart version is injected during packaging. This PR creates a separate Dart publish tag whose commit contains the baked Dart version.

## What changed
- Dart flexible-version git dependencies now emit:
  - `tag_pattern: "{{version}}-dart-publish"`
  - a semver `version`
- Release workflows create a detached Dart publish commit/tag with the baked `pubspec.yaml` version.
- Only `release` events push the publish tag and publish artifacts/packages.
- `setup.dart` supports both old `ref` lockfiles and new `tag_pattern` lockfiles.
- Updated the Dart workflow template and regenerated TestAPI workflows.

## How it works
For a release tag like `1.2.3`:

1. The release workflow checks out tag `1.2.3`.
2. CI writes `version: "1.2.3"` into the Dart package pubspec.
3. CI creates a detached commit containing that publish-specific change.
4. CI tags that commit as `1.2.3-dart-publish`.
5. The release workflow pushes the publish tag and publishes from the same run.

Consumers using flexible Dart versions resolve against the publish-only tags via:

```yaml
tag_pattern: "{{version}}-dart-publish"
```
