### PR TITLE
provide git credentials to CI step for submodule checkout

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,7 +31,7 @@ jobs:
       COVERAGE_MODE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'baseline' || 'report' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -31,7 +31,7 @@ jobs:
       CONFIGURATION: debug
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up java
         uses: actions/setup-java@v5
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up java
         uses: actions/setup-java@v5
@@ -284,7 +284,7 @@ jobs:
       FISHYJOES: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: compnerd/gha-setup-swift@main
         with:

--- a/.github/workflows/iota-runtime.yaml
+++ b/.github/workflows/iota-runtime.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build FishyJoesIotaRuntime
         shell: zsh {0}
@@ -48,7 +48,7 @@ jobs:
       LIB_DIR: .build/linux-iota-libs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure build environment
         run: |
@@ -89,7 +89,7 @@ jobs:
       LIB_DIR: .build/windows-iota-libs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: compnerd/gha-setup-swift@main
         with:
@@ -143,7 +143,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up node
         uses: actions/setup-node@v6

--- a/.github/workflows/java-runtime.yaml
+++ b/.github/workflows/java-runtime.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up java
         uses: actions/setup-java@v5
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up java
         uses: actions/setup-java@v5
@@ -130,7 +130,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: compnerd/gha-setup-swift@main
         with:
@@ -176,7 +176,7 @@ jobs:
       - build-test-kotlin-windows
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up java
         uses: actions/setup-java@v5

--- a/.github/workflows/node-runtime.yaml
+++ b/.github/workflows/node-runtime.yaml
@@ -25,7 +25,7 @@ jobs:
       LIB_DIR: node-runtime/fishyjoes-runtime-native-macos
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build FishyJoesNodeRuntime
         shell: zsh {0}
@@ -83,7 +83,7 @@ jobs:
       LIB_DIR: node-runtime/fishyjoes-runtime-native-ubuntu
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up node
         uses: actions/setup-node@v6
@@ -150,7 +150,7 @@ jobs:
       LIB_DIR: node-runtime/fishyjoes-runtime-native-windows
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: compnerd/gha-setup-swift@main
         with:

--- a/.github/workflows/swiftlint.yaml
+++ b/.github/workflows/swiftlint.yaml
@@ -14,7 +14,7 @@ jobs:
     container:
       image: ghcr.io/realm/swiftlint:0.53.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/Sources/FishyJoesExecute/FileTemplater.swift
+++ b/Sources/FishyJoesExecute/FileTemplater.swift
@@ -61,9 +61,9 @@ public struct FileTemplater {
         let lines = ciPreBuildHook.split(separator: "\n").map(String.init)
         replacements["__PRE_BUILD_HOOK_YAML__"] = "|" + join(lines: lines, indent: 10)
 
-        let credentialStepLines: [String]
-        let credentialUser: String
-        let credentialToken: String
+        var credentialStepLines: [String] = []
+        var credentialUser: String = ""
+        var credentialToken: String = ""
         var ciEnv: [String: String] = [
             "FISHYJOES": "1",
             "JAVA_VERSION": "20",
@@ -87,20 +87,26 @@ public struct FileTemplater {
                 userAndToken = token
             }
             credentialStepLines = [
-                "name: Setup git credentials",
-                "uses: de-vri-es/setup-git-credentials@5dd446b3857806f44ea73acf83c193190a385d63  # v2.2.0",
-                "with:",
-                "  credentials: https://\(userAndToken)@github.com/",
-            ]
-        } else {
-            credentialUser = ""
-            credentialToken = ""
-            credentialStepLines = [
-                "name: Setup git credentials (none provided/needed)",
-                "run: \"\"",
+                "- name: Setup git credentials",
+                "  uses: de-vri-es/setup-git-credentials@5dd446b3857806f44ea73acf83c193190a385d63  # v2.2.0",
+                "  with:",
+                "    credentials: https://\(userAndToken)@github.com/",
+                "",
             ]
         }
-        replacements["__CI_SETUP_GIT_CREDENTIALS_STEP__"] = join(lines: credentialStepLines, indent: 8).trimmed()
+        credentialStepLines.append(
+            contentsOf: [
+                "- name: Checkout",
+                "  uses: actions/checkout@v6",
+                "  with:",
+                "    submodules: recursive",
+            ]
+        )
+        if credentialToken != "" {
+            credentialStepLines.append("    token: '\(credentialToken)'")
+        }
+        credentialStepLines[0].removeFirst(2) // remove the first "- " so that the template can also be valid yaml
+        replacements["__CI_GIT_STEPS__"] = join(lines: credentialStepLines, indent: 6).trimmed()
         replacements["__CI_DEPENDENCY_AUTH_USER__"] = credentialUser
         replacements["__CI_DEPENDENCY_AUTH_TOKEN__"] = credentialToken
         let envLines = ciEnv.sorted { $0.key < $1.key }.map { "\($0.key): '\($0.value)'" }

--- a/Sources/FishyJoesExecute/FileTemplater.swift
+++ b/Sources/FishyJoesExecute/FileTemplater.swift
@@ -102,7 +102,7 @@ public struct FileTemplater {
                 "    submodules: recursive",
             ]
         )
-        if credentialToken != "" {
+        if !credentialToken.isEmpty {
             credentialStepLines.append("    token: '\(credentialToken)'")
         }
         credentialStepLines[0].removeFirst(2) // remove the first "- " so that the template can also be valid yaml

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-c-sharp.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-c-sharp.yaml
@@ -23,12 +23,7 @@ jobs:
     name: "macOS: Build and test C# bindings"
     runs-on: __CI_RUNNER_MACOS__
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Set up node
         uses: actions/setup-node@v6
@@ -78,12 +73,7 @@ jobs:
     name: "Ubuntu: Build and test C# bindings"
     runs-on: __CI_RUNNER_UBUNTU__
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Set up node
         uses: actions/setup-node@v6
@@ -144,18 +134,13 @@ jobs:
     name: "Windows: Build and test C# bindings"
     runs-on: __CI_RUNNER_WINDOWS__
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
       - name: Configure git and vcpkg
         shell: pwsh
         run: |
           git config --system core.longpaths true
           echo "VCPKG_ROOT=$(Split-Path -Parent $((gcm vcpkg).Path))" >> $env:GITHUB_ENV
 
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Set up dotnet
         uses: actions/setup-dotnet@v5
@@ -220,12 +205,7 @@ jobs:
     env:
       GITHUB_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Set up dotnet
         uses: actions/setup-dotnet@v5

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
@@ -23,12 +23,7 @@ jobs:
     name: "macOS: Build and test dart bindings"
     runs-on: __CI_RUNNER_MACOS__
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Set up node
         uses: actions/setup-node@v6
@@ -73,12 +68,7 @@ jobs:
     name: "Ubuntu: Build and test dart bindings"
     runs-on: __CI_RUNNER_UBUNTU__
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Set up node
         uses: actions/setup-node@v6
@@ -136,18 +126,13 @@ jobs:
     name: "Windows: Build and test dart bindings"
     runs-on: __CI_RUNNER_WINDOWS__
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
       - name: Configure git and vcpkg
         shell: pwsh
         run: |
           git config --system core.longpaths true
           echo "VCPKG_ROOT=$(Split-Path -Parent $((gcm vcpkg).Path))" >> $env:GITHUB_ENV
 
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Set up node
         uses: actions/setup-node@v6
@@ -209,12 +194,7 @@ jobs:
       - build-test-dart-linux
       - build-test-dart-windows
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Set up node
         uses: actions/setup-node@v6

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-kotlin.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-kotlin.yaml
@@ -23,12 +23,7 @@ jobs:
     name: "macOS: Build and test kotlin bindings"
     runs-on: __CI_RUNNER_MACOS__
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Set up java
         uses: actions/setup-java@v5
@@ -72,12 +67,7 @@ jobs:
     name: "Ubuntu: Build and test kotlin bindings"
     runs-on: __CI_RUNNER_UBUNTU__
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Set up java
         uses: actions/setup-java@v5
@@ -148,18 +138,13 @@ jobs:
     name: "Windows: Build and test kotlin bindings"
     runs-on: __CI_RUNNER_WINDOWS__
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
       - name: Configure git and vcpkg
         shell: pwsh
         run: |
           git config --system core.longpaths true
           echo "VCPKG_ROOT=$(Split-Path -Parent $((gcm vcpkg).Path))" >> $env:GITHUB_ENV
 
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - uses: compnerd/gha-setup-swift@main
         with:
@@ -226,12 +211,7 @@ jobs:
     env:
       GITHUB_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Set up java
         uses: actions/setup-java@v5

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-regenerate-check.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-regenerate-check.yaml
@@ -19,12 +19,7 @@ jobs:
     name: "macOS: regenerate check"
     runs-on: __CI_RUNNER_MACOS__
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Install generation tools
         shell: zsh {0}

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-typescript.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-typescript.yaml
@@ -23,12 +23,7 @@ jobs:
     name: "macOS: Build and test typescript bindings"
     runs-on: __CI_RUNNER_MACOS__
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Install generation tools
         shell: zsh {0}
@@ -93,12 +88,7 @@ jobs:
     name: "Ubuntu: Build and test typescript bindings"
     runs-on: __CI_RUNNER_UBUNTU__
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Set up node
         uses: actions/setup-node@v6
@@ -171,18 +161,13 @@ jobs:
     name: "Windows: Build and test typescript bindings"
     runs-on: __CI_RUNNER_WINDOWS__
     steps:
-      - __CI_SETUP_GIT_CREDENTIALS_STEP__
-
       - name: Configure git and vcpkg
         shell: pwsh
         run: |
           git config --system core.longpaths true
           echo "VCPKG_ROOT=$(Split-Path -Parent $((gcm vcpkg).Path))" >> $env:GITHUB_ENV
 
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - __CI_GIT_STEPS__
 
       - name: Set up node
         uses: actions/setup-node@v6

--- a/Sources/FishyJoesExecute/Utilities.swift
+++ b/Sources/FishyJoesExecute/Utilities.swift
@@ -278,5 +278,5 @@ func relativePath(of targetPath: String, relativeTo sourcePath: String) -> Strin
 }
 
 func join(lines: [String], indent: Int) -> String {
-    lines.map { "\n\(String(repeating: " ", count: indent))\($0)" }.joined()
+    lines.map { "\n\($0.isEmpty ? "" : String(repeating: " ", count: indent))\($0)" }.joined()
 }

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-c-sharp.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-c-sharp.yaml
@@ -27,11 +27,8 @@ jobs:
     name: "macOS: Build and test C# bindings"
     runs-on: macos-26
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -84,11 +81,8 @@ jobs:
     name: "Ubuntu: Build and test C# bindings"
     runs-on: ubuntu-latest
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -152,9 +146,6 @@ jobs:
     name: "Windows: Build and test C# bindings"
     runs-on: windows-2025
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Configure git and vcpkg
         shell: pwsh
         run: |
@@ -162,7 +153,7 @@ jobs:
           echo "VCPKG_ROOT=$(Split-Path -Parent $((gcm vcpkg).Path))" >> $env:GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -230,11 +221,8 @@ jobs:
     env:
       GITHUB_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
@@ -27,11 +27,8 @@ jobs:
     name: "macOS: Build and test dart bindings"
     runs-on: macos-26
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -79,11 +76,8 @@ jobs:
     name: "Ubuntu: Build and test dart bindings"
     runs-on: ubuntu-latest
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -144,9 +138,6 @@ jobs:
     name: "Windows: Build and test dart bindings"
     runs-on: windows-2025
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Configure git and vcpkg
         shell: pwsh
         run: |
@@ -154,7 +145,7 @@ jobs:
           echo "VCPKG_ROOT=$(Split-Path -Parent $((gcm vcpkg).Path))" >> $env:GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -219,11 +210,8 @@ jobs:
       - build-test-dart-linux
       - build-test-dart-windows
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-kotlin.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-kotlin.yaml
@@ -27,11 +27,8 @@ jobs:
     name: "macOS: Build and test kotlin bindings"
     runs-on: macos-26
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -78,11 +75,8 @@ jobs:
     name: "Ubuntu: Build and test kotlin bindings"
     runs-on: ubuntu-latest
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -156,9 +150,6 @@ jobs:
     name: "Windows: Build and test kotlin bindings"
     runs-on: windows-2025
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Configure git and vcpkg
         shell: pwsh
         run: |
@@ -166,7 +157,7 @@ jobs:
           echo "VCPKG_ROOT=$(Split-Path -Parent $((gcm vcpkg).Path))" >> $env:GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -236,11 +227,8 @@ jobs:
     env:
       GITHUB_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-regenerate-check.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-regenerate-check.yaml
@@ -23,11 +23,8 @@ jobs:
     name: "macOS: regenerate check"
     runs-on: macos-26
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-typescript.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-typescript.yaml
@@ -27,11 +27,8 @@ jobs:
     name: "macOS: Build and test typescript bindings"
     runs-on: macos-26
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -99,11 +96,8 @@ jobs:
     name: "Ubuntu: Build and test typescript bindings"
     runs-on: ubuntu-latest
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -179,9 +173,6 @@ jobs:
     name: "Windows: Build and test typescript bindings"
     runs-on: windows-2025
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Configure git and vcpkg
         shell: pwsh
         run: |
@@ -189,7 +180,7 @@ jobs:
           echo "VCPKG_ROOT=$(Split-Path -Parent $((gcm vcpkg).Path))" >> $env:GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-c-sharp.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-c-sharp.yaml
@@ -27,11 +27,8 @@ jobs:
     name: "macOS: Build and test C# bindings"
     runs-on: macos-26
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -84,11 +81,8 @@ jobs:
     name: "Ubuntu: Build and test C# bindings"
     runs-on: ubuntu-latest
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -152,9 +146,6 @@ jobs:
     name: "Windows: Build and test C# bindings"
     runs-on: windows-2025
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Configure git and vcpkg
         shell: pwsh
         run: |
@@ -162,7 +153,7 @@ jobs:
           echo "VCPKG_ROOT=$(Split-Path -Parent $((gcm vcpkg).Path))" >> $env:GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -230,11 +221,8 @@ jobs:
     env:
       GITHUB_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-dart.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-dart.yaml
@@ -27,11 +27,8 @@ jobs:
     name: "macOS: Build and test dart bindings"
     runs-on: macos-26
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -79,11 +76,8 @@ jobs:
     name: "Ubuntu: Build and test dart bindings"
     runs-on: ubuntu-latest
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -144,9 +138,6 @@ jobs:
     name: "Windows: Build and test dart bindings"
     runs-on: windows-2025
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Configure git and vcpkg
         shell: pwsh
         run: |
@@ -154,7 +145,7 @@ jobs:
           echo "VCPKG_ROOT=$(Split-Path -Parent $((gcm vcpkg).Path))" >> $env:GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -219,11 +210,8 @@ jobs:
       - build-test-dart-linux
       - build-test-dart-windows
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-kotlin.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-kotlin.yaml
@@ -27,11 +27,8 @@ jobs:
     name: "macOS: Build and test kotlin bindings"
     runs-on: macos-26
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -78,11 +75,8 @@ jobs:
     name: "Ubuntu: Build and test kotlin bindings"
     runs-on: ubuntu-latest
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -156,9 +150,6 @@ jobs:
     name: "Windows: Build and test kotlin bindings"
     runs-on: windows-2025
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Configure git and vcpkg
         shell: pwsh
         run: |
@@ -166,7 +157,7 @@ jobs:
           echo "VCPKG_ROOT=$(Split-Path -Parent $((gcm vcpkg).Path))" >> $env:GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -236,11 +227,8 @@ jobs:
     env:
       GITHUB_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-regenerate-check.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-regenerate-check.yaml
@@ -23,11 +23,8 @@ jobs:
     name: "macOS: regenerate check"
     runs-on: macos-26
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-typescript.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-typescript.yaml
@@ -27,11 +27,8 @@ jobs:
     name: "macOS: Build and test typescript bindings"
     runs-on: macos-26
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -99,11 +96,8 @@ jobs:
     name: "Ubuntu: Build and test typescript bindings"
     runs-on: ubuntu-latest
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -179,9 +173,6 @@ jobs:
     name: "Windows: Build and test typescript bindings"
     runs-on: windows-2025
     steps:
-      - name: Setup git credentials (none provided/needed)
-        run: ""
-
       - name: Configure git and vcpkg
         shell: pwsh
         run: |
@@ -189,7 +180,7 @@ jobs:
           echo "VCPKG_ROOT=$(Split-Path -Parent $((gcm vcpkg).Path))" >> $env:GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 


### PR DESCRIPTION
CI was failing in tesseract because both the setup-git-credentials step and the actions/checkout step need the non-default token. Now checked that it works in Tesseract ( https://github.com/cricut/Tesseract/actions/runs/25882486034?pr=153 )