### PR TITLE
fix dart publish token

### DIFF
--- a/.github/workflows/iota-runtime.yaml
+++ b/.github/workflows/iota-runtime.yaml
@@ -243,6 +243,10 @@ jobs:
       - name: Push Dart publish tag
         if: github.event_name == 'release'
         shell: zsh {0}
+        env:
+          GH_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
         run: |
           set -euxo pipefail
 
@@ -251,7 +255,8 @@ jobs:
               exit 0
           fi
 
-          git push origin "refs/tags/$PUBLISH_TAG"
+          git remote add publish-origin https://$GH_PUBLISH_TOKEN@github.com/$OWNER/$REPO.git
+          git push publish-origin "refs/tags/$PUBLISH_TAG"
 
       - name: Pack
         shell: zsh {0}

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-dart.yaml
@@ -281,6 +281,10 @@ jobs:
       - name: Push Dart publish tag
         if: github.event_name == 'release'
         shell: zsh {0}
+        env:
+          GH_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
         run: |
           set -euxo pipefail
 
@@ -289,7 +293,8 @@ jobs:
               exit 0
           fi
 
-          git push origin "refs/tags/$PUBLISH_TAG"
+          git remote add publish-origin https://$GH_PUBLISH_TOKEN@github.com/$OWNER/$REPO.git
+          git push publish-origin "refs/tags/$PUBLISH_TAG"
 
       - name: Pack
         shell: zsh {0}

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
@@ -300,6 +300,10 @@ jobs:
       - name: Push Dart publish tag
         if: github.event_name == 'release'
         shell: zsh {0}
+        env:
+          GH_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
         run: |
           set -euxo pipefail
 
@@ -308,7 +312,8 @@ jobs:
               exit 0
           fi
 
-          git push origin "refs/tags/$PUBLISH_TAG"
+          git remote add publish-origin https://$GH_PUBLISH_TOKEN@github.com/$OWNER/$REPO.git
+          git push publish-origin "refs/tags/$PUBLISH_TAG"
 
       - name: Pack
         shell: zsh {0}

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-dart.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-dart.yaml
@@ -300,6 +300,10 @@ jobs:
       - name: Push Dart publish tag
         if: github.event_name == 'release'
         shell: zsh {0}
+        env:
+          GH_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
         run: |
           set -euxo pipefail
 
@@ -308,7 +312,8 @@ jobs:
               exit 0
           fi
 
-          git push origin "refs/tags/$PUBLISH_TAG"
+          git remote add publish-origin https://$GH_PUBLISH_TOKEN@github.com/$OWNER/$REPO.git
+          git push publish-origin "refs/tags/$PUBLISH_TAG"
 
       - name: Pack
         shell: zsh {0}


### PR DESCRIPTION
Changes to the auth setup downstream caused git to have a non-writing token for the dart publish step. This replaces it with the CI's primary token, which has write permissions.