### PR TITLE
chore(AB#830016): publish android artifact to jfrog artifactory

### DIFF
--- a/.github/workflows/java-runtime.yaml
+++ b/.github/workflows/java-runtime.yaml
@@ -223,6 +223,7 @@ jobs:
         if: github.event_name == 'release'
         env:
           GITHUB_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JFROG_TOKEN: ${{ secrets.JFROG_PROD_ACCESS_TOKEN }}
         run: |
           set -euxo pipefail
 

--- a/Sources/FishyJoesExecute/Resources/bindings-template/kotlin/__TEMPLATE__/build.gradle.kts
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/kotlin/__TEMPLATE__/build.gradle.kts
@@ -56,6 +56,20 @@ publishing {
                 password = System.getenv("GITHUB_PUBLISH_TOKEN")
             }
         }
+        val jfrogCiToken = System.getenv("JFROG_TOKEN")
+        if (!jfrogCiToken.isNullOrEmpty()) {
+            maven {
+                name = "cricut-maven"
+                url = uri("https://packages.cricut.com/artifactory/cricut-maven")
+                authentication {
+                    create("header", HttpHeaderAuthentication::class)
+                }
+                credentials(HttpHeaderCredentials::class) {
+                    name = "Authorization"
+                    value = "Bearer $jfrogCiToken"
+                }
+            }
+        }
     }
     publications {
         create<MavenPublication>("mavenJava") {

--- a/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-kotlin.yaml
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-kotlin.yaml
@@ -213,6 +213,7 @@ jobs:
     if: success()
     env:
       GITHUB_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      JFROG_TOKEN: ${{ secrets.JFROG_PROD_ACCESS_TOKEN }}
     steps:
       - __CI_GIT_STEPS__
 

--- a/kotlin-runtime/build.gradle.kts
+++ b/kotlin-runtime/build.gradle.kts
@@ -45,6 +45,20 @@ publishing {
                 password = System.getenv("GITHUB_PUBLISH_TOKEN")
             }
         }
+        val jfrogCiToken = System.getenv("JFROG_TOKEN")
+        if (!jfrogCiToken.isNullOrEmpty()) {
+            maven {
+                name = "cricut-maven"
+                url = uri("https://packages.cricut.com/artifactory/cricut-maven")
+                authentication {
+                    create("header", HttpHeaderAuthentication::class)
+                }
+                credentials(HttpHeaderCredentials::class) {
+                    name = "Authorization"
+                    value = "Bearer $jfrogCiToken"
+                }
+            }
+        }
     }
     publications {
         create<MavenPublication>("mavenJava") {


### PR DESCRIPTION
## Changes

Adds JFrog Artifactory as a publish target for Android artifacts generated by FishyJoes bindings. These are template files that get stamped out into all consuming repos when bindings are regenerated, plus the kotlin-runtime which is published directly from FishyJoes itself.

### `Sources/FishyJoesExecute/Resources/bindings-template/kotlin/__TEMPLATE__/build.gradle.kts`
- Registered a second Maven publishing repository pointing to `https://packages.cricut.com/artifactory/cricut-maven`
- Uses `HttpHeaderAuthentication` with a Bearer token sourced from the `JFROG_TOKEN` environment variable

### `Sources/FishyJoesExecute/Resources/bindings-template/workflows/__TEMPLATE_CAPS__-kotlin.yaml`
- Added `JFROG_TOKEN: ${{ secrets.JFROG_PROD_ACCESS_TOKEN }}` to the `kotlin-publish` job's env block

### `kotlin-runtime/build.gradle.kts`
- Same JFrog Artifactory repository registration as the template above

### `.github/workflows/java-runtime.yaml`
- Added `JFROG_TOKEN: ${{ secrets.JFROG_PROD_ACCESS_TOKEN }}` to the `Publish` step's env block