### PR TITLE
chore: replace de-vri-es/setup-git-credentials with cricut/actions/setup-netrc

### DIFF
--- a/Sources/FishyJoesExecute/FileTemplater.swift
+++ b/Sources/FishyJoesExecute/FileTemplater.swift
@@ -77,20 +77,20 @@ public struct FileTemplater {
             ciEnv["GITHUB_TOKEN"] = token
             ciEnv["NODE_AUTH_TOKEN"] = token
             ciEnv["NUGET_AUTH_TOKEN"] = token
-            let userAndToken: String
             if let user = config.ciDependencyAuth?.user {
                 ciEnv["GITHUB_USER"] = user
                 credentialUser = user
-                userAndToken = "\(user):\(token)"
             } else {
                 credentialUser = ""
-                userAndToken = token
             }
+            // setup-netrc writes ~/.netrc directly instead of mutating
+            // `git config credential.helper`, which accumulates stale values
+            // on persistent self-hosted runners and fails subsequent jobs with
+            // `cannot overwrite multiple values with a single value`.
             credentialStepLines = [
-                "- name: Setup git credentials",
-                "  uses: de-vri-es/setup-git-credentials@5dd446b3857806f44ea73acf83c193190a385d63  # v2.2.0",
+                "- uses: cricut/actions/.github/actions/setup-netrc@9316fb92c29e1903fb4188772540d9aff06e4cbb # v4.1.0",
                 "  with:",
-                "    credentials: https://\(userAndToken)@github.com/",
+                "    token: \(token)",
                 "",
             ]
         }


### PR DESCRIPTION
## Summary

`de-vri-es/setup-git-credentials@v2` fails on persistent self-hosted runners once `credential.helper` has accumulated multiple values from previous jobs:

```
error: cannot overwrite multiple values with a single value
##[error]The process '/usr/bin/git' failed with exit code 5
```

The action runs `git config credential.helper https://USER:TOKEN@github.com/`; on long-lived `sojo-*` runners that config value has multiple entries from earlier jobs, so git refuses the overwrite. Live repro in CriGeo: https://github.com/cricut/CriGeo/actions/runs/27065543700/job/79885658750?pr=322

## Change

`Sources/FishyJoesExecute/FileTemplater.swift` — swap the emitted credentials step from:

```yaml
- name: Setup git credentials
  uses: de-vri-es/setup-git-credentials@5dd446b3857806f44ea73acf83c193190a385d63  # v2.2.0
  with:
    credentials: https://USER:TOKEN@github.com/
```

to:

```yaml
- uses: cricut/actions/.github/actions/setup-netrc@9316fb92c29e1903fb4188772540d9aff06e4cbb # v4.1.0
  with:
    token: TOKEN
```

`setup-netrc` writes `~/.netrc` directly instead of mutating git's credential-helper chain, so it can't collide with stale state on the runner. The default `hosts: github.com api.github.com` and `login: oauth2` from the composite action are correct for SPM resolution via git.

## Why this is safe

- The replacement composite action is **already in production** across every artemis CI workflow and across the hand-maintained workflows on the `CriGeo:main` branch (after PR cricut/CriGeo#324 lands). Same pin, same secret.
- Both actions exist purely to authenticate `git clone` / SPM resolve to private GitHub. `git` reads `~/.netrc` as a credential fallback via libcurl when `credential.helper` doesn't produce a match, so netrc is functionally equivalent for the auth path that matters here.
- Code change is minimal: 6-line replacement inside the `if let token = config.ciDependencyAuth?.token` branch; `credentialUser` / `credentialToken` placeholders and env vars (`GITHUB_TOKEN`, `GITHUB_USER`, etc.) are unchanged.

## Downstream effect

Next time any project running `swift run -- fishy-joes generate` regenerates its `bindings/workflows/GENERATED-*.yaml` and `.github/workflows/GENERATED-*.yaml`, the credentials step will pick up the new action. No project config changes required.

## Test plan

- [ ] FishyJoes integration-tests CI passes (TestAPI has no `CIDependencyAuth`, so it doesn't exercise the changed branch, but the build must still succeed).
- [ ] After release: cricut/CriGeo bumps FishyJoes, runs `swift run -- fishy-joes generate`, and the resulting `GENERATED-*.yaml` workflows contain `setup-netrc` instead of `de-vri-es/setup-git-credentials` — and the existing regenerate-check job (which was the original motivation for cricut/CriGeo#324's partial revert) starts passing on PRs that touch the new generated workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
