### PR TITLE
Update copy-linux-swift-stdlib.sh

### DIFF
--- a/scripts/copy-linux-swift-stdlib.sh
+++ b/scripts/copy-linux-swift-stdlib.sh
@@ -109,6 +109,7 @@ if [[ ! -z ${FISHYJOES_UBUNTU_DEST:-} ]]; then
     ubuntuRoots=(
         $runtimeLibraryPath/libFoundation.so
         $runtimeLibraryPath/libFoundationXML.so
+        $runtimeLibraryPath/libswiftSwiftOnoneSupport.so
         /usr/lib/x86_64-linux-gnu/libxml2.so.2
 
         # Uncomment this if networking is needed


### PR DESCRIPTION
flutter was missing this file for linux:

Launching lib/main.dart on Linux in debug mode...
CMake Error at cmake_install.cmake:412 (file):
  file INSTALL cannot find
  "/home/mroylance/cricut/roylance_research/tooligans/linux/flutter/ephemeral/.plugin_symlinks/fishyjoes_dart/linux/native/libswiftSwiftOnoneSupport.so":
  No such file or directory.


Building Linux application...                                           
Error: Build process failed
