### PR TITLE
fix(kotlin): register sourcesElements variant in Gradle module metadata

### DIFF
--- a/Sources/FishyJoesExecute/Resources/bindings-template/kotlin/__TEMPLATE__/build.gradle.kts
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/kotlin/__TEMPLATE__/build.gradle.kts
@@ -24,9 +24,11 @@ repositories {
     }
 }
 
-val sourcesJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("sources")
-    from(sourceSets.main.get().allSource)
+java {
+    withSourcesJar()
+}
+
+tasks.named<Jar>("sourcesJar") {
     exclude("**/*.so", "**/*.dylib", "**/*.dll")
 }
 
@@ -64,7 +66,6 @@ publishing {
             version = properties["version"] as? String
 
             from(components["java"])
-            artifact(sourcesJar.get())
 
             pom {
                 name.set("__MODULE_NAME__")

--- a/integration-tests/TestAPI/bindings/kotlin/generated/build.gradle.kts
+++ b/integration-tests/TestAPI/bindings/kotlin/generated/build.gradle.kts
@@ -24,9 +24,11 @@ repositories {
     }
 }
 
-val sourcesJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("sources")
-    from(sourceSets.main.get().allSource)
+java {
+    withSourcesJar()
+}
+
+tasks.named<Jar>("sourcesJar") {
     exclude("**/*.so", "**/*.dylib", "**/*.dll")
 }
 
@@ -64,7 +66,6 @@ publishing {
             version = properties["version"] as? String
 
             from(components["java"])
-            artifact(sourcesJar.get())
 
             pom {
                 name.set("TestAPI")

--- a/kotlin-runtime/build.gradle.kts
+++ b/kotlin-runtime/build.gradle.kts
@@ -13,9 +13,11 @@ repositories {
     mavenCentral()
 }
 
-val sourcesJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("sources")
-    from(sourceSets.main.get().allSource)
+java {
+    withSourcesJar()
+}
+
+tasks.named<Jar>("sourcesJar") {
     exclude("**/*.so", "**/*.dylib", "**/*.dll")
 }
 
@@ -53,9 +55,6 @@ publishing {
             version = properties["version"] as? String
 
             from(components["java"])
-            artifact(sourcesJar.get()) {
-                classifier = "sources"
-            }
         }
     }
 }


### PR DESCRIPTION
## Problem

The Kotlin bindings template used a manually registered `sourcesJar` task and attached it via `artifact(sourcesJar.get())` in the `MavenPublication` block. This correctly uploads the `-sources.jar` to the package registry and references it in the POM, but **does not add a `sourcesElements` variant to the Gradle Module Metadata (`.module` file)**.

Since Gradle 6+, when both a `.module` file and a POM are present, Gradle (and Android Studio) prefer the `.module` file exclusively. Without a `sourcesElements` variant in `.module`, sources are invisible to Gradle's dependency resolution — even though the JAR exists in the registry and the POM references it. The POM-embedded `<!-- do_not_remove: published-with-gradle-metadata -->` marker ensures the `.module` file always wins, so consumer-side workarounds (e.g. `metadataSources { mavenPom() }`) are also ineffective.

This has affected all bindings generated from this template (e.g. `cricanvas`, `crigeo`, `critext`, `crisvg`, `criraster`) across all published versions.

## Fix

Replace the manual task + `artifact()` approach with `java { withSourcesJar() }`, which:
- Creates the `sourcesJar` task automatically
- **Registers a `sourcesElements` variant in the `.module` file** — the missing piece
- Attaches the sources JAR to the Maven publication via the `java` component automatically

The native binary exclusion (`*.so`, `*.dylib`, `*.dll`) is preserved by configuring the auto-created task via `tasks.named<Jar>("sourcesJar")`.

## Test plan

- [ ] Trigger a new binding release (e.g. CriCanvas) from this template
- [ ] Verify the published `.module` file contains a `sourcesElements` variant
- [ ] Verify Android Studio auto-downloads sources when navigating into a binding class

🤖 Generated with [Claude Code](https://claude.com/claude-code)