### PR TITLE
feat(node): accept a caller-supplied wasm source in generated init()

### DIFF
--- a/Sources/FishyJoesExecute/Phases/NodePhases.swift
+++ b/Sources/FishyJoesExecute/Phases/NodePhases.swift
@@ -301,8 +301,16 @@ class NodePhases: BasePhases, Phases {
             definitions.append("")
         }
 
-        // Export a function that can be used to load the module and its dependencies using a promise
-        definitions.append("export declare function init(): Promise<{")
+        // Export a function that can be used to load the module and its dependencies using a promise.
+        // Wasm builds accept an optional caller-supplied binary source (shared-download hosts);
+        // native builds keep the zero-argument form — their init ignores no arguments silently.
+        if platform == .wasm {
+            definitions.append(
+                "export declare function init(wasmSource?: Response | PromiseLike<Response> | BufferSource | WebAssembly.Module): Promise<{"
+            )
+        } else {
+            definitions.append("export declare function init(): Promise<{")
+        }
         for dependency in nodeDependencies {
             definitions.append("    \(dependency.name): typeof \(dependency.name),")
         }

--- a/Sources/FishyJoesNodeRuntime/Templates/__MODULE_NAME__.browser.js
+++ b/Sources/FishyJoesNodeRuntime/Templates/__MODULE_NAME__.browser.js
@@ -12,7 +12,19 @@ import * as __MODULE_DEPENDENCY__Extensions from "./__MODULE_DEPENDENCY__.extens
 let __MODULE_NAME__;
 let __MODULE_DEPENDENCY__;
 
-const init = async () => {
+/**
+ * Initialize the Wasm module.
+ *
+ * `wasmSource` optionally supplies the binary, so a host that already holds it
+ * (or shares one download between the main thread and workers) can instantiate
+ * without this module fetching it again:
+ * - `WebAssembly.Module`: instantiated directly (compile is skipped).
+ * - `ArrayBuffer` / typed array view: compiled and instantiated from bytes.
+ * - `Response` or a promise of one (e.g. a `fetch(...)` call): streamed;
+ *   the response must carry `Content-Type: application/wasm`.
+ * - omitted: fetches "__MODULE_NAME__.wasm" relative to the document, as before.
+ */
+const init = async (wasmSource) => {
   let napi = new NAPI(WASI, WasmFs);
   const importObject = {};
   const importsToMerge = [
@@ -29,10 +41,14 @@ const init = async () => {
     }
   }
 
-  const response = await fetch("__MODULE_NAME__.wasm");
-  const wasmPromise = WebAssembly.instantiateStreaming(response, importObject);
-  const { instance } = await wasmPromise;
-  console.log(instance);
+  let instance;
+  if (wasmSource instanceof WebAssembly.Module) {
+    instance = await WebAssembly.instantiate(wasmSource, importObject);
+  } else if (wasmSource instanceof ArrayBuffer || ArrayBuffer.isView(wasmSource)) {
+    ({ instance } = await WebAssembly.instantiate(wasmSource, importObject));
+  } else {
+    ({ instance } = await WebAssembly.instantiateStreaming(wasmSource ?? fetch("__MODULE_NAME__.wasm"), importObject));
+  }
   const library = napi.init(instance);
   ({
     __MODULE_NAME__,

--- a/Sources/FishyJoesNodeRuntime/Templates/__MODULE_NAME__.js
+++ b/Sources/FishyJoesNodeRuntime/Templates/__MODULE_NAME__.js
@@ -4,7 +4,18 @@ import { WasmFs } from "@wasmer/wasmfs";
 import * as __MODULE_NAME__Extensions from "./__MODULE_NAME__.extensions.js";
 import * as __MODULE_DEPENDENCY__Extensions from "./__MODULE_DEPENDENCY__.extensions.js";
 
-export const init = async () => {
+/**
+ * Initialize the Wasm module.
+ *
+ * `wasmSource` optionally supplies the binary so the host can share one copy
+ * instead of this module loading it again:
+ * - `WebAssembly.Module`: instantiated directly (compile is skipped).
+ * - `ArrayBuffer` / typed array view: compiled and instantiated from bytes.
+ * - `Response` or a promise of one: read into bytes, then instantiated
+ *   (byte path, so it works on runtimes without `instantiateStreaming`).
+ * - omitted: bundler `fetch` or filesystem read of "__MODULE_NAME__.wasm", as before.
+ */
+export const init = async (wasmSource) => {
   let napi = new NAPI(WASI, WasmFs);
   const importObject = {};
   const importsToMerge = [
@@ -21,20 +32,25 @@ export const init = async () => {
     }
   }
 
-  let wasmPromise
-  if (typeof(__webpack_require__) === 'function' && typeof(fetch) === 'function') {
+  let instance;
+  if (wasmSource instanceof WebAssembly.Module) {
+    instance = await WebAssembly.instantiate(wasmSource, importObject);
+  } else if (wasmSource !== undefined) {
+    const binary = wasmSource instanceof ArrayBuffer || ArrayBuffer.isView(wasmSource)
+      ? wasmSource
+      : await (await wasmSource).arrayBuffer();
+    ({ instance } = await WebAssembly.instantiate(binary, importObject));
+  } else if (typeof(__webpack_require__) === 'function' && typeof(fetch) === 'function') {
     const response = await import("./__MODULE_NAME__.wasm").then((module) => fetch(module.default));
-    wasmPromise = WebAssembly.instantiateStreaming(response, importObject);
+    ({ instance } = await WebAssembly.instantiateStreaming(response, importObject));
   } else {
     const path = await import(/* webpackIgnore: true */ 'path');
     const url = await import(/* webpackIgnore: true */ 'url');
     const fs = await import(/* webpackIgnore: true */ 'fs');
     const dirname = path.dirname(url.fileURLToPath(import.meta.url));
     const binary = fs.readFileSync(path.join(dirname, '__MODULE_NAME__.wasm'));
-    wasmPromise = WebAssembly.instantiate(binary, importObject);
+    ({ instance } = await WebAssembly.instantiate(binary, importObject));
   }
-  const { instance } = await wasmPromise;
-  // console.log(instance);
   const library = napi.init(instance);
   __MODULE_DEPENDENCY__Extensions.applyExtensions(library, { wasmNapi: napi });
   __MODULE_NAME__Extensions.applyExtensions(library, { wasmNapi: napi });


### PR DESCRIPTION
[AB#836126](https://cricut.visualstudio.com/c2d3f832-807c-402a-8eed-789cbf6d601a/_workitems/edit/836126)

## Problem

The generated wasm `init()` hardcodes its own binary load (browser template: `fetch("<Module>.wasm")` + `instantiateStreaming`; node template: bundler fetch or filesystem read). Every context a host initializes — the main thread plus each worker — therefore downloads and compiles the full binary again. For CriCanvas (~65 MB raw) in DesignSpace-web, a cold canvas boot pays that three or more times: main thread, the cricanvas worker, and each thread of a render worker pool.

This was review feedback on a consumer-side workaround (CricutDesignSpaceCanvas#7353, closed as superseded): the root fix belongs here, in the glue the exporter generates.

## Change

`init(wasmSource?)` in both node-runtime templates:

- `WebAssembly.Module` → instantiated directly (compile skipped)
- `ArrayBuffer` / typed-array view → compiled + instantiated from bytes
- `Response` or `PromiseLike<Response>` (e.g. a `fetch(...)` call) → **streamed** in the browser template; **normalized to bytes** in the node template so nothing depends on `instantiateStreaming` support in the runtime
- omitted → previous behavior, byte-for-byte unchanged

The generated `.d.ts` declaration widens to `init(wasmSource?: Response | PromiseLike<Response> | BufferSource | WebAssembly.Module)` for **wasm builds only** — native node builds keep the zero-argument form since their init takes no source. Also drops a stray `console.log(instance)` that ships in every wasm package today.

Every FishyJoes-exported wasm module gains the capability (`cricanvas-wasm`, `crigeo-wasm`, `criraster-wasm`, `critrace-wasm`, `physicalcanvas-wasm`, runtime).

## Validation (why this is a draft)

- Local: placeholder-substituted templates parse clean as ES modules (`node --check`); `NodePhases.swift` parses; `platform == .wasm` is the established in-scope comparison in `installPhase()`.
- Downstream, against a hand-patched `cricanvas-wasm@3.25.29` carrying this exact glue transform: the DesignSpace SPA + CricutDesignSpaceCanvas single-download integration (`grancier/CIT-836126-wasm-source-boot`) typechecks and builds green end-to-end; browser runtime verification is in progress.
- NOT yet run: this repo's generation pipeline (`fishy-joes --nodejs --wasm build/test/pack`) — CI on this PR is the first real execution. Marking ready once it's green and the downstream runtime test confirms a single network fetch.

## Consumption sequence

FishyJoes release → CriCanvas bumps `fishyJoesVersion` + tags → regenerated `@cricut/cricanvas-wasm` publishes → CricutDesignSpaceCanvas lands its `init(getWasmSource())` boot-message branch with the pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)