### PR TITLE
Default generated C# projects to .NET 10, with a DotNet opt-out

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -18,7 +18,7 @@ concurrency:
 env:
   JAVA_VERSION: '20'
   NODE_VERSION: '18.x'
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   GITHUB_USER: ${{ github.actor }}
   GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -18,7 +18,7 @@ concurrency:
 env:
   JAVA_VERSION: '20'
   NODE_VERSION: '18.x'
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   GITHUB_USER: ${{ github.actor }}
   GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/iota-runtime.yaml
+++ b/.github/workflows/iota-runtime.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   NODE_VERSION: '18.x'
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
 
 jobs:
   build-iota-mac:

--- a/Sources/FishyJoesExecute/FileTemplater.swift
+++ b/Sources/FishyJoesExecute/FileTemplater.swift
@@ -57,6 +57,11 @@ public struct FileTemplater {
         replacements["__CI_RUNNER_UBUNTU__"] = (config.ciRunners ?? .defaults).ubuntu
         replacements["__CI_RUNNER_WINDOWS__"] = (config.ciRunners ?? .defaults).windows
 
+        // Set here rather than in CSharpPhases: `fishy-joes init` builds a FileTemplater
+        // with no phases, and the scaffolded csproj still needs a target framework.
+        let dotNet = config.dotNet ?? .defaults
+        replacements["__CSPROJ_TARGET_FRAMEWORK__"] = dotNet.targetFramework
+
         let ciPreBuildHook = config.ciPreBuildHook ?? "# Build customization can be added here with the `CIPreBuildHook` key in fishy-joes.yaml"
         let preBuildHookLines = ciPreBuildHook.split(separator: "\n").map(String.init)
         replacements["__PRE_BUILD_HOOK_YAML__"] = "|" + join(lines: preBuildHookLines, indent: 10)
@@ -72,7 +77,7 @@ public struct FileTemplater {
             "FISHYJOES": "1",
             "JAVA_VERSION": "20",
             "NODE_VERSION": "18.x",
-            "DOTNET_VERSION": "8.0.x",
+            "DOTNET_VERSION": dotNet.sdkVersion,
             "GRADLE_OPTS": "-Dorg.gradle.daemon=false",
         ]
 

--- a/Sources/FishyJoesExecute/PackageInit.swift
+++ b/Sources/FishyJoesExecute/PackageInit.swift
@@ -90,7 +90,8 @@ public struct PackageInit: ParsableCommand {
             flexibleVersions: false,
             sourceryOverride: nil,
             ciRunners: nil,
-            ciDependencyAuth: nil
+            ciDependencyAuth: nil,
+            dotNet: nil
         )
 
         let encoder = YAMLEncoder()

--- a/Sources/FishyJoesExecute/ProjectConfig.swift
+++ b/Sources/FishyJoesExecute/ProjectConfig.swift
@@ -27,8 +27,9 @@ struct ProjectConfig: Codable {
     let ciDependencyAuth: CIDependencyAuth?
 
     // Which .NET SDK CI installs, and which target framework the generated
-    // C# projects build against. Lets a repo move to a newer .NET without
-    // waiting for every other FishyJoes consumer to move at the same time.
+    // C# projects build against. Defaults to .NET 10; a repo that still has a
+    // downstream consumer on an older runtime can pin it back here instead of
+    // waiting on a FishyJoes release.
     let dotNet: DotNet?
 
     enum SourceryOverride {
@@ -53,7 +54,7 @@ struct ProjectConfig: Codable {
         let sdkVersion: String      // `dotnet-version` for actions/setup-dotnet, e.g. "10.0.x"
         let targetFramework: String // csproj `<TargetFramework>`, e.g. "net10.0"
 
-        static let defaults = DotNet(sdkVersion: "8.0.x", targetFramework: "net8.0")
+        static let defaults = DotNet(sdkVersion: "10.0.x", targetFramework: "net10.0")
     }
 
     static func readFromFile(basePath: String) throws -> ProjectConfig {

--- a/Sources/FishyJoesExecute/ProjectConfig.swift
+++ b/Sources/FishyJoesExecute/ProjectConfig.swift
@@ -26,6 +26,11 @@ struct ProjectConfig: Codable {
     // Authorization that may be needed to fetch any dependencies of the library
     let ciDependencyAuth: CIDependencyAuth?
 
+    // Which .NET SDK CI installs, and which target framework the generated
+    // C# projects build against. Lets a repo move to a newer .NET without
+    // waiting for every other FishyJoes consumer to move at the same time.
+    let dotNet: DotNet?
+
     enum SourceryOverride {
         case local(String?) // Local sourcery binary. Will search PATH if nil
         case remote(String) // Run a specific version using mint
@@ -42,6 +47,13 @@ struct ProjectConfig: Codable {
     struct CIDependencyAuth: Codable {
         let user: String?
         let token: String
+    }
+
+    struct DotNet: Codable {
+        let sdkVersion: String      // `dotnet-version` for actions/setup-dotnet, e.g. "10.0.x"
+        let targetFramework: String // csproj `<TargetFramework>`, e.g. "net10.0"
+
+        static let defaults = DotNet(sdkVersion: "8.0.x", targetFramework: "net8.0")
     }
 
     static func readFromFile(basePath: String) throws -> ProjectConfig {
@@ -67,6 +79,9 @@ struct ProjectConfig: Codable {
             Log.error("  macos: \(CIRunners.defaults.macos)  # default")
             Log.error("  ubuntu: \(CIRunners.defaults.ubuntu)  # default")
             Log.error("  windows: \(CIRunners.defaults.windows)  # default")
+            Log.error("DotNet:")
+            Log.error("  sdkVersion: \(DotNet.defaults.sdkVersion)  # default")
+            Log.error("  targetFramework: \(DotNet.defaults.targetFramework)  # default")
             throw ValidationError("invalid YAML")
         }
         guard let moduleObj = configDictionary["module"] else {
@@ -143,6 +158,15 @@ struct ProjectConfig: Codable {
             }
             return CIDependencyAuth(user: dict["user"] as? String, token: token)
         }
+        let dotNet = try configDictionary["DotNet"].map { obj -> DotNet in
+            guard let dict = obj as? [String: Any] else {
+                throw ValidationError("fishy-joes.yaml value for key `DotNet` is not a [String: String] dictionary")
+            }
+            return DotNet(
+                sdkVersion: dict["sdkVersion"] as? String ?? DotNet.defaults.sdkVersion,
+                targetFramework: dict["targetFramework"] as? String ?? DotNet.defaults.targetFramework,
+            )
+        }
 
         return ProjectConfig(
             module: module,
@@ -155,7 +179,8 @@ struct ProjectConfig: Codable {
             flexibleVersions: flexibleVersions,
             sourceryOverride: sourceryOverride,
             ciRunners: ciRunners,
-            ciDependencyAuth: ciDependencyAuth
+            ciDependencyAuth: ciDependencyAuth,
+            dotNet: dotNet
         )
     }
 }

--- a/Sources/FishyJoesExecute/Resources/bindings-template/c-sharp/Cricut.__MODULE_NAME__.Tests/Cricut.__MODULE_NAME__.Tests.csproj
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/c-sharp/Cricut.__MODULE_NAME__.Tests/Cricut.__MODULE_NAME__.Tests.csproj
@@ -9,14 +9,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4"></PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1"></PackageReference>
-    <PackageReference Include="Xunit.Extensions.Ordering" Version="1.4.5" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"></PackageReference>
+    <PackageReference Include="xunit" Version="2.9.3"></PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Sources/FishyJoesExecute/Resources/bindings-template/c-sharp/Cricut.__MODULE_NAME__.Tests/Cricut.__MODULE_NAME__.Tests.csproj
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/c-sharp/Cricut.__MODULE_NAME__.Tests/Cricut.__MODULE_NAME__.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>__CSPROJ_TARGET_FRAMEWORK__</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Sources/FishyJoesExecute/Resources/bindings-template/c-sharp/Cricut.__MODULE_NAME__.Tests/Cricut.__MODULE_NAME__.Tests.csproj
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/c-sharp/Cricut.__MODULE_NAME__.Tests/Cricut.__MODULE_NAME__.Tests.csproj
@@ -10,12 +10,12 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"></PackageReference>
-    <PackageReference Include="xunit" Version="2.9.3"></PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit" Version="2.4.1"></PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Sources/FishyJoesExecute/Resources/bindings-template/c-sharp/__TEMPLATE__/Cricut.__MODULE_NAME__/Cricut.__MODULE_NAME__.csproj
+++ b/Sources/FishyJoesExecute/Resources/bindings-template/c-sharp/__TEMPLATE__/Cricut.__MODULE_NAME__/Cricut.__MODULE_NAME__.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">__CSPROJ_DEPENDENCIES__
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>__CSPROJ_TARGET_FRAMEWORK__</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RepositoryUrl>https://__BINDINGS_REPO__</RepositoryUrl>

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-c-sharp.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-c-sharp.yaml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   FISHYJOES: '1'
   GRADLE_OPTS: '-Dorg.gradle.daemon=false'
   JAVA_VERSION: '20'

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-dart.yaml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   FISHYJOES: '1'
   GRADLE_OPTS: '-Dorg.gradle.daemon=false'
   JAVA_VERSION: '20'

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-kotlin.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-kotlin.yaml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   FISHYJOES: '1'
   GRADLE_OPTS: '-Dorg.gradle.daemon=false'
   JAVA_VERSION: '20'

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-regenerate-check.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-regenerate-check.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   FISHYJOES: '1'
   GRADLE_OPTS: '-Dorg.gradle.daemon=false'
   JAVA_VERSION: '20'

--- a/integration-tests/TestAPI/.github/workflows/GENERATED-typescript.yaml
+++ b/integration-tests/TestAPI/.github/workflows/GENERATED-typescript.yaml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   FISHYJOES: '1'
   GRADLE_OPTS: '-Dorg.gradle.daemon=false'
   JAVA_VERSION: '20'

--- a/integration-tests/TestAPI/bindings/c-sharp/Cricut.TestAPI.Tests/Cricut.TestAPI.Tests.csproj
+++ b/integration-tests/TestAPI/bindings/c-sharp/Cricut.TestAPI.Tests/Cricut.TestAPI.Tests.csproj
@@ -10,12 +10,12 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"></PackageReference>
-    <PackageReference Include="xunit" Version="2.9.3"></PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit" Version="2.4.1"></PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/integration-tests/TestAPI/bindings/c-sharp/Cricut.TestAPI.Tests/Cricut.TestAPI.Tests.csproj
+++ b/integration-tests/TestAPI/bindings/c-sharp/Cricut.TestAPI.Tests/Cricut.TestAPI.Tests.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4"></PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1"></PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"></PackageReference>
+    <PackageReference Include="xunit" Version="2.9.3"></PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/integration-tests/TestAPI/bindings/c-sharp/Cricut.TestAPI.Tests/Cricut.TestAPI.Tests.csproj
+++ b/integration-tests/TestAPI/bindings/c-sharp/Cricut.TestAPI.Tests/Cricut.TestAPI.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/integration-tests/TestAPI/bindings/c-sharp/DebugMe/DebugMe.csproj
+++ b/integration-tests/TestAPI/bindings/c-sharp/DebugMe/DebugMe.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration-tests/TestAPI/bindings/c-sharp/generated/Cricut.TestAPI/Cricut.TestAPI.csproj
+++ b/integration-tests/TestAPI/bindings/c-sharp/generated/Cricut.TestAPI/Cricut.TestAPI.csproj
@@ -5,7 +5,7 @@
   <ItemGroup><PackageReference Include="Cricut.FishyJoesRuntime" Version="[0.0.1-unknown]" /></ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RepositoryUrl>https://__BINDINGS_REPO__</RepositoryUrl>

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-c-sharp.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-c-sharp.yaml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   FISHYJOES: '1'
   GRADLE_OPTS: '-Dorg.gradle.daemon=false'
   JAVA_VERSION: '20'

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-dart.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-dart.yaml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   FISHYJOES: '1'
   GRADLE_OPTS: '-Dorg.gradle.daemon=false'
   JAVA_VERSION: '20'

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-kotlin.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-kotlin.yaml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   FISHYJOES: '1'
   GRADLE_OPTS: '-Dorg.gradle.daemon=false'
   JAVA_VERSION: '20'

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-regenerate-check.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-regenerate-check.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   FISHYJOES: '1'
   GRADLE_OPTS: '-Dorg.gradle.daemon=false'
   JAVA_VERSION: '20'

--- a/integration-tests/TestAPI/bindings/workflows/GENERATED-typescript.yaml
+++ b/integration-tests/TestAPI/bindings/workflows/GENERATED-typescript.yaml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   FISHYJOES: '1'
   GRADLE_OPTS: '-Dorg.gradle.daemon=false'
   JAVA_VERSION: '20'


### PR DESCRIPTION
## Problem

The .NET SDK that generated CI workflows install, and the target framework of the generated C# projects, were both hardcoded:

- `Sources/FishyJoesExecute/FileTemplater.swift` — `"DOTNET_VERSION": "8.0.x"` in `ciEnv`
- `bindings-template/c-sharp/__TEMPLATE__/.../Cricut.__MODULE_NAME__.csproj` — `net8.0`
- `bindings-template/c-sharp/Cricut.__MODULE_NAME__.Tests/....csproj` — `net8.0`

There was no `fishy-joes.yaml` override for either, unlike `CIRunners` / `CIPreBuildHook`, and hand-editing the generated files fails `GENERATED-regenerate-check`. **.NET 8 leaves LTS support in November 2026**, and all ten consumer repos generate a C# binding at `net8.0` today:

`Bifrost` · `CriCanvas` · `CriGeo` · `CriRaster` · `CriSVG` · `CriText` · `CriTrace` · `Tesseract` · `PhysicalCanvas` · `CriAnalytics`

Worth noting the status quo is also a latent trap: those workflows install the 8.0.x SDK and then run a `net10.0` project in `CIPreBuildHook`. It works only because there's no `global.json`, so `dotnet` picks the runner image's newer SDK. Add a `global.json` — or have the image drop .NET 10 — and all five workflows break at once.

## Change

**Generated C# projects and workflows now default to .NET 10** (`10.0.x` / `net10.0`). Consumers pick it up on their next regeneration.

A new `DotNet` key in `fishy-joes.yaml` is the opt-out, following the existing `CIRunners` pattern — for any repo that finds a downstream consumer still on an older runtime and needs to pin back without waiting on a FishyJoes release:

```yaml
DotNet:
  sdkVersion: 8.0.x
  targetFramework: net8.0
```

Both sub-keys are optional and fall back individually.

## What else moved, and why

- **`integration-tests/TestAPI` regenerated** for the new defaults.
- **`Cricut.TestAPI.Tests` and `DebugMe` bumped to net10.0.** Neither is regenerated — their paths aren't marked generated, so `installBehavior` skips them — but both `ProjectReference` the now-net10 library, and a net8 project can't do that.
- **`Microsoft.NET.Test.Sdk` 16.9.4 → 18.5.1** in `TestAPI` and the template. Required, not housekeeping: the .NET 10 SDK audits transitive packages, the test projects set `TreatWarningsAsErrors`, and 16.9.4 depends on `Newtonsoft.Json` 9.0.1 (GHSA-5crp-9r3c-p9vr, high) — so restore fails with `NU1903` as an error until the SDK moves.
- **`Xunit.Extensions.Ordering` 1.4.5 dropped from the template.** Unused (empty example test, no orderer anywhere), abandoned upstream, and it pulls `Microsoft.NETCore.App` 1.0.5 + `Microsoft.NETCore.Jit` 1.0.7, which fail the same audit.
- **FishyJoes' own `coverage` / `integration-tests` / `iota-runtime` workflows bumped off `8.0.x`** — the TestAPI binding no longer builds under an 8.0 SDK.
- **`c-sharp-runtime/Cricut.FishyJoesRuntime.csproj` deliberately stays at `net8.0`** — a net10 project consumes a net8.0 package fine, and raising it would force every consumer forward with no way back. Multi-targeting it is a reasonable follow-up.

xunit, `xunit.runner.visualstudio` and `coverlet.collector` are deliberately left on their original versions. Bumping xunit to 2.9.3 brings a much stricter analyzer set, which turned pre-existing `xUnit2000` violations in `TestAPI/.../RangeTests.cs` into errors under `TreatWarningsAsErrors`. Modernizing those is worth doing, but not in this PR.

## ⚠️ What each consumer repo has to do by hand

Regeneration moves only the generated half. On its next regen, each of the other nine repos will also need, in its own commit:

1. Its hand-maintained binding **test project** (and any `DebugMe`-style helper) moved to `net10.0` — these are not regenerated.
2. `Microsoft.NET.Test.Sdk` bumped, for the `NU1903` reason above.
3. Whatever *its own* test code trips once the .NET 10 SDK starts enforcing audits and analyzers that the 8.0 SDK did not. This part is repo-specific and can't be predicted from here.

A repo that gets blocked on (3) can set `DotNet.targetFramework: net8.0` and defer, rather than waiting on a FishyJoes release.

## Verification

- **Regenerate check green** (macOS job, `integration-tests.yaml` L62–73): regeneration produces a zero-byte diff against the `TestAPI` output committed here.
- **macOS + Ubuntu/Android integration tests green**, including `Test C♯ from dotnet via fishy-joes` on net10.
- The `NU1903` and `xUnit2000` failure modes above were both reproduced and fixed against a local net10 project carrying the real `TreatWarningsAsErrors` setting and the real `RangeTests` argument order.
- I don't have a Swift toolchain, so the Swift build is CI's word, not mine.

**`Windows: Integration tests` is red on `main` too** — third-party `setup-dart` / `gha-setup-swift` drift, dies before any build step. Three-run comparison in the comment below. Needs its own fix; not from this PR.

## Known gap

`DotNet.sdkVersion` and `DotNet.targetFramework` are independent and unvalidated, so `sdkVersion: 8.0.x` + `targetFramework: net10.0` is configurable and guaranteed to break. Deriving one from the other would be wrong — `sdkVersion: 10.0.x` + `targetFramework: net8.0` is a legitimate combination — so a guard rejecting an SDK major below the TFM major is the fix. Happy to add it here if a reviewer wants it.
